### PR TITLE
MSMARCO support: monoBERT

### DIFF
--- a/pygaggle/data/__init__.py
+++ b/pygaggle/data/__init__.py
@@ -1,2 +1,3 @@
 from .kaggle import *
 from .relevance import *
+from .msmarco import *

--- a/pygaggle/data/msmarco.py
+++ b/pygaggle/data/msmarco.py
@@ -1,0 +1,147 @@
+import os
+from collections import OrderedDict, defaultdict
+from typing import List, Set, OrderedDict, defaultdict
+import json
+import logging
+from itertools import permutations
+
+from pydantic import BaseModel
+import scipy.special as sp
+import numpy as np
+
+from .relevance import RelevanceExample, Cord19DocumentLoader
+from pygaggle.model.tokenize import SpacySenticizer
+from pygaggle.rerank.base import Query, Text
+from pygaggle.data.unicode import convert_to_unicode
+
+
+__all__ = ['MsMarcoExample', 'MsMarcoDataset']
+
+
+class MsMarcoExample(BaseModel):
+    qid: str
+    text: str
+    candidates: List[str]
+    relevant_candidates: Set[str]
+
+class MsMarcoDataset(BaseModel):
+    examples: List[MsMarcoExample]
+
+    @classmethod
+    def load_qrels(cls, path: str) -> DefaultDict[str, Set[str]]:
+        qrels = defaultdict(set)
+        with open(path) as f:
+            for i, line in enumerate(f):
+                qid, _, doc_id, _ = line.rstrip().split('\t')
+                if int(relevance) >= 1:
+                    qrels[qid].add(doc_id)
+                if i % 1000 == 0:
+                    print(f'Loading qrels {i}')
+        return qrels
+
+    @classmethod
+    def load_run(cls, path: str) -> OrderedDict[str, List[str]]:
+        run = OrderedDict()
+        if "eval" in path:
+            return run
+        with open(path) as f:
+            for i, line in enumerate(f):
+                qid, doc_title, rank = line.split('\t')
+                if qid not in run:
+                    run[qid] = []
+                run[qid].append((doc_title, int(rank)))
+                if i % 1000000 == 0:
+                    print(f'Loading run {i}')
+        sorted_run = OrderedDict()
+        for qid, doc_titles_ranks in run.items():
+            sorted(doc_titles_ranks, key=lambda x: x[1])
+            doc_titles = [doc_titles for doc_titles, _ in doc_titles_ranks]
+            sorted_run[qid] = doc_titles
+        return sorted_run
+
+    @classmethod
+    def load_queries(cls, 
+                     path: str, 
+                     qrels: DefaultDict[str, Set[str]], 
+                     run: OrderedDict[str, List[str]]) -> List[MsMarcoExample]:
+        queries = []
+        with open(path) as f:
+            for i, line in enumerate(f):
+                qid, query = line.rstrip().split('\t')
+                try:
+                    candidates = run[qid]
+                queries.append(MsMarcoExample(qid = qid,
+                                              query = query,
+                                              candidates = run[qid],
+                                              relevant_candidates = qrels[qid]))
+                if i % 1000 == 0:
+                    print(f'Loading queries {i}')
+        return queries
+
+    @classmethod
+    def from_folder(cls, 
+                    folder: str, 
+                    split: str = 'dev', 
+                    is_duo: bool = False) -> 'MsMarcoDataset':
+        with open(filename) as f:
+            run_mono = "mono." if is_duo else ""
+            query_path = os.path.join(f"queries.{split}.small.tsv")
+            qrels_path = os.path.join(f"qrels.{split}.small.tsv")
+            run_path = os.path.join(f"run.{run_mono}{split}.small.tsv")
+            return cls(cls.load_queries(query_path, 
+                                        cls.load_qrels(qrels_path),
+                                        cls.load_run(run_path)))
+
+
+    def query_passage_tuples(self, is_duo: bool = False):
+        return (((ex.qid, ex.text, ex.relevant_candidates), perm_pas) for ex in self.examples
+                for perm_pas in permutations(ex.candidates, r=1+int(is_duo)))
+
+    
+    def to_relevance_examples(self,
+                              index_path: str,
+                              is_duo: bool = False) -> List[RelevanceExample]:
+        loader = MsMarcoPassageLoader(index_path)
+        example_map = {}
+        for (qid, text, rel_cands), cands in self.query_answer_pairs():
+            if qid not in example_map:
+                example_map[qid] = [convert_to_unicode(text), [], [], []]
+            #TODO generalize for duoBERT by removing indexing to 0
+            example_map[qid][1].append([cand for cand in cands][0])
+            try:
+                passages = [loader.load_passage(cand) for cand in cands]
+                #TODO generalize for duoBERT by removing indexing to 0
+                example_map[qid][2].append([convert_to_unicode(passage.all_text) for passage in passages][0]) 
+            except ValueError as e:
+                logging.warning(f'Skipping {passages}')
+                continue
+            #TODO generalize for duoBERT by adding indexing cands to 0
+            example_map[qid][3].append(cands in rel_cands)
+        mean_stats = defaultdict(list)
+        for ex in self.examples:
+            int_rels = np.array(list(map(int, example_map[ex.qid][3])))
+            p = int_rels.sum()/(len(candidates) - 1) if is_duo else int_rels.sum()
+            mean_stats['Random P@1'].append(np.mean(int_rels))
+            n = len(candidates) - p
+            N = len(candidates)
+            if len(candidates) <= 1000:
+                mean_stats['Random R@1000'].append(1 if 1 in int_rels else 0)
+            numer = np.array([sp.comb(n, i) / (N - i) for i in range(0, n + 1)]) * p
+            denom = np.array([sp.comb(N, i) for i in range(0, n + 1)])
+            rr = 1 / np.arange(1, n + 2)
+            rmrr = np.sum(numer * rr / denom)
+            mean_stats['Random MRR'].append(rmrr)
+            rmrr10 = np.sum(numer[:10] * rr[:10] / denom[:10]) #TODO verify if this works
+            mean_stats['Random MRR@10'].append(rmmr10)
+            ex_index = len(candidates)
+            for rel_cand in ex.relevant_candidates:
+                if rel_cand in ex.candidates:
+                    ex_index = min(ex.candidates.index(rel_cand), ex_index)
+            mean_stats['Existing MRR'].append(1 / (ex_index + 1) if ex_index < len(candidates) else 0)
+            mean_stats['Existing MRR@10'].append(1 / (ex_index + 1) if ex_index < 10 else 0)
+        for k, v in mean_stats.items():
+            logging.info(f'{k}: {np.mean(v)}')
+        return [RelevanceExample(Query(query_text, qid), 
+                                 list(map(lambda s: Text(s[0], dict(docid=key[1])), zip(cands, cands_text))), 
+                                 rel_cands) \
+                for qid, (query_text, cands, cands_text, rel_cands) in example_map.items()]

--- a/pygaggle/data/msmarco.py
+++ b/pygaggle/data/msmarco.py
@@ -103,11 +103,9 @@ class MsMarcoDataset(BaseModel):
         for (qid, text, rel_cands), cands in self.query_passage_tuples():
             if qid not in example_map:
                 example_map[qid] = [convert_to_unicode(text), [], [], []]
-            #TODO generalize for duoBERT by removing indexing to 0
             example_map[qid][1].append([cand for cand in cands][0])
             try:
                 passages = [loader.load_passage(cand) for cand in cands]
-                #TODO generalize for duoBERT by removing indexing to 0
                 example_map[qid][2].append([convert_to_unicode(passage.all_text) for passage in passages][0]) 
             except ValueError as e:
                 logging.warning(f'Skipping {passages}')
@@ -129,7 +127,7 @@ class MsMarcoDataset(BaseModel):
             rr = 1 / np.arange(1, n + 2)
             rmrr = np.sum(numer * rr / denom)
             mean_stats['Random MRR'].append(rmrr)
-            rmrr10 = np.sum(numer[:10] * rr[:10] / denom[:10]) #TODO verify if this works
+            rmrr10 = np.sum(numer[:10] * rr[:10] / denom[:10])
             mean_stats['Random MRR@10'].append(rmrr10)
             ex_index = len(ex.candidates)
             for rel_cand in ex.relevant_candidates:

--- a/pygaggle/data/msmarco.py
+++ b/pygaggle/data/msmarco.py
@@ -1,6 +1,6 @@
 import os
 from collections import OrderedDict, defaultdict
-from typing import List, Set, OrderedDict, defaultdict
+from typing import List, Set, DefaultDict
 import json
 import logging
 from itertools import permutations
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 import scipy.special as sp
 import numpy as np
 
-from .relevance import RelevanceExample, Cord19DocumentLoader
+from .relevance import RelevanceExample, MsMarcoPassageLoader
 from pygaggle.model.tokenize import SpacySenticizer
 from pygaggle.rerank.base import Query, Text
 from pygaggle.data.unicode import convert_to_unicode
@@ -32,7 +32,7 @@ class MsMarcoDataset(BaseModel):
         qrels = defaultdict(set)
         with open(path) as f:
             for i, line in enumerate(f):
-                qid, _, doc_id, _ = line.rstrip().split('\t')
+                qid, _, doc_id, relevance = line.rstrip().split('\t')
                 if int(relevance) >= 1:
                     qrels[qid].add(doc_id)
                 if i % 1000 == 0:
@@ -40,10 +40,9 @@ class MsMarcoDataset(BaseModel):
         return qrels
 
     @classmethod
-    def load_run(cls, path: str) -> OrderedDict[str, List[str]]:
+    def load_run(cls, path: str):
+        '''Returns OrderedDict[str, List[str]]'''
         run = OrderedDict()
-        if "eval" in path:
-            return run
         with open(path) as f:
             for i, line in enumerate(f):
                 qid, doc_title, rank = line.split('\t')
@@ -63,15 +62,14 @@ class MsMarcoDataset(BaseModel):
     def load_queries(cls, 
                      path: str, 
                      qrels: DefaultDict[str, Set[str]], 
-                     run: OrderedDict[str, List[str]]) -> List[MsMarcoExample]:
+                     run) -> List[MsMarcoExample]:
         queries = []
         with open(path) as f:
             for i, line in enumerate(f):
                 qid, query = line.rstrip().split('\t')
-                try:
-                    candidates = run[qid]
+                candidates = run[qid]
                 queries.append(MsMarcoExample(qid = qid,
-                                              query = query,
+                                              text = query,
                                               candidates = run[qid],
                                               relevant_candidates = qrels[qid]))
                 if i % 1000 == 0:
@@ -83,27 +81,26 @@ class MsMarcoDataset(BaseModel):
                     folder: str, 
                     split: str = 'dev', 
                     is_duo: bool = False) -> 'MsMarcoDataset':
-        with open(filename) as f:
-            run_mono = "mono." if is_duo else ""
-            query_path = os.path.join(f"queries.{split}.small.tsv")
-            qrels_path = os.path.join(f"qrels.{split}.small.tsv")
-            run_path = os.path.join(f"run.{run_mono}{split}.small.tsv")
-            return cls(cls.load_queries(query_path, 
-                                        cls.load_qrels(qrels_path),
-                                        cls.load_run(run_path)))
+        run_mono = "mono." if is_duo else ""
+        query_path = os.path.join(folder, f"queries.{split}.small.tsv")
+        qrels_path = os.path.join(folder, f"qrels.{split}.small.tsv")
+        run_path = os.path.join(folder, f"run.{run_mono}{split}.small.tsv")
+        return cls(examples = cls.load_queries(query_path, 
+                                               cls.load_qrels(qrels_path),
+                                               cls.load_run(run_path)))
 
 
     def query_passage_tuples(self, is_duo: bool = False):
         return (((ex.qid, ex.text, ex.relevant_candidates), perm_pas) for ex in self.examples
                 for perm_pas in permutations(ex.candidates, r=1+int(is_duo)))
 
-    
+
     def to_relevance_examples(self,
                               index_path: str,
                               is_duo: bool = False) -> List[RelevanceExample]:
         loader = MsMarcoPassageLoader(index_path)
         example_map = {}
-        for (qid, text, rel_cands), cands in self.query_answer_pairs():
+        for (qid, text, rel_cands), cands in self.query_passage_tuples():
             if qid not in example_map:
                 example_map[qid] = [convert_to_unicode(text), [], [], []]
             #TODO generalize for duoBERT by removing indexing to 0
@@ -115,33 +112,34 @@ class MsMarcoDataset(BaseModel):
             except ValueError as e:
                 logging.warning(f'Skipping {passages}')
                 continue
-            #TODO generalize for duoBERT by adding indexing cands to 0
-            example_map[qid][3].append(cands in rel_cands)
+            example_map[qid][3].append(cands[0] in rel_cands)
         mean_stats = defaultdict(list)
         for ex in self.examples:
             int_rels = np.array(list(map(int, example_map[ex.qid][3])))
-            p = int_rels.sum()/(len(candidates) - 1) if is_duo else int_rels.sum()
+            p = int_rels.sum()/(len(ex.candidates) - 1) if is_duo else int_rels.sum()
             mean_stats['Random P@1'].append(np.mean(int_rels))
-            n = len(candidates) - p
-            N = len(candidates)
-            if len(candidates) <= 1000:
+            n = len(ex.candidates) - p
+            N = len(ex.candidates)
+            if len(ex.candidates) <= 1000:
                 mean_stats['Random R@1000'].append(1 if 1 in int_rels else 0)
-            numer = np.array([sp.comb(n, i) / (N - i) for i in range(0, n + 1)]) * p
+            numer = np.array([sp.comb(n, i) / (N - i) for i in range(0, n + 1) if i!=N]) * p
+            if n == N:
+                numer = np.append(numer, 0)
             denom = np.array([sp.comb(N, i) for i in range(0, n + 1)])
             rr = 1 / np.arange(1, n + 2)
             rmrr = np.sum(numer * rr / denom)
             mean_stats['Random MRR'].append(rmrr)
             rmrr10 = np.sum(numer[:10] * rr[:10] / denom[:10]) #TODO verify if this works
-            mean_stats['Random MRR@10'].append(rmmr10)
-            ex_index = len(candidates)
+            mean_stats['Random MRR@10'].append(rmrr10)
+            ex_index = len(ex.candidates)
             for rel_cand in ex.relevant_candidates:
                 if rel_cand in ex.candidates:
                     ex_index = min(ex.candidates.index(rel_cand), ex_index)
-            mean_stats['Existing MRR'].append(1 / (ex_index + 1) if ex_index < len(candidates) else 0)
+            mean_stats['Existing MRR'].append(1 / (ex_index + 1) if ex_index < len(ex.candidates) else 0)
             mean_stats['Existing MRR@10'].append(1 / (ex_index + 1) if ex_index < 10 else 0)
         for k, v in mean_stats.items():
             logging.info(f'{k}: {np.mean(v)}')
-        return [RelevanceExample(Query(query_text, qid), 
-                                 list(map(lambda s: Text(s[0], dict(docid=key[1])), zip(cands, cands_text))), 
+        return [RelevanceExample(Query(text=query_text, id=qid), 
+                                 list(map(lambda s: Text(s[1], dict(docid=s[0])), zip(cands, cands_text))), 
                                  rel_cands) \
                 for qid, (query_text, cands, cands_text, rel_cands) in example_map.items()]

--- a/pygaggle/data/msmarco.py
+++ b/pygaggle/data/msmarco.py
@@ -35,8 +35,6 @@ class MsMarcoDataset(BaseModel):
                 qid, _, doc_id, relevance = line.rstrip().split('\t')
                 if int(relevance) >= 1:
                     qrels[qid].add(doc_id)
-                if i % 1000 == 0:
-                    print(f'Loading qrels {i}')
         return qrels
 
     @classmethod
@@ -49,8 +47,6 @@ class MsMarcoDataset(BaseModel):
                 if qid not in run:
                     run[qid] = []
                 run[qid].append((doc_title, int(rank)))
-                if i % 1000000 == 0:
-                    print(f'Loading run {i}')
         sorted_run = OrderedDict()
         for qid, doc_titles_ranks in run.items():
             sorted(doc_titles_ranks, key=lambda x: x[1])
@@ -72,8 +68,6 @@ class MsMarcoDataset(BaseModel):
                                               text = query,
                                               candidates = run[qid],
                                               relevant_candidates = qrels[qid]))
-                if i % 1000 == 0:
-                    print(f'Loading queries {i}')
         return queries
 
     @classmethod

--- a/pygaggle/data/relevance.py
+++ b/pygaggle/data/relevance.py
@@ -65,7 +65,6 @@ class MsMarcoPassageLoader:
     def __init__(self, index_path: str):
         self.searcher = pysearch.SimpleSearcher(index_path)
 
-    @lru_cache(maxsize=1024) #TODO any point in this here?
     def load_passage(self, id: str) -> MsMarcoPassage:
         try:
             passage = self.searcher.doc(id).lucene_document().get('raw')

--- a/pygaggle/data/relevance.py
+++ b/pygaggle/data/relevance.py
@@ -36,7 +36,7 @@ class MsMarcoPassage:
 
     @property
     def all_text(self):
-        return para_text
+        return self.para_text
 
 
 class Cord19DocumentLoader:

--- a/pygaggle/data/relevance.py
+++ b/pygaggle/data/relevance.py
@@ -30,6 +30,15 @@ class Cord19Document:
         return '\n'.join((self.abstract, self.body_text, self.ref_entries))
 
 
+@dataclass
+class MsMarcoPassage:
+    para_text: str
+
+    @property
+    def all_text(self):
+        return para_text
+
+
 class Cord19DocumentLoader:
     double_space_pattern = re.compile(r'\s\s+')
 
@@ -50,3 +59,16 @@ class Cord19DocumentLoader:
         return Cord19Document(unfold(article['abstract']),
                               unfold(article['body_text']),
                               unfold(ref_entries))
+
+
+class MsMarcoPassageLoader:
+    def __init__(self, index_path: str):
+        self.searcher = pysearch.SimpleSearcher(index_path)
+
+    @lru_cache(maxsize=1024) #TODO any point in this here?
+    def load_passage(self, id: str) -> MsMarcoPassage:
+        try:
+            passage = self.searcher.doc(id).lucene_document().get('raw')
+        except AttributeError:
+            raise ValueError('passage unretrievable')
+        return MsMarcoPassage(passage)

--- a/pygaggle/data/unicode.py
+++ b/pygaggle/data/unicode.py
@@ -1,22 +1,8 @@
-import unicodedata
-import six
-
-
 def convert_to_unicode(text):
-  """Converts `text` to Unicode (if it's not already), assuming utf-8 input."""
-  if six.PY3:
+    """Converts `text` to Unicode (if it's not already), assuming utf-8 input."""
     if isinstance(text, str):
-      return text
+        return text
     elif isinstance(text, bytes):
-      return text.decode("utf-8", "ignore")
+        return text.decode("utf-8", "ignore")
     else:
-      raise ValueError("Unsupported string type: %s" % (type(text)))
-  elif six.PY2:
-    if isinstance(text, str):
-      return text.decode("utf-8", "ignore")
-    elif isinstance(text, unicode):
-      return text
-    else:
-      raise ValueError("Unsupported string type: %s" % (type(text)))
-  else:
-    raise ValueError("Not running on Python2 or Python 3?")
+        raise ValueError("Unsupported string type: %s" % (type(text)))

--- a/pygaggle/data/unicode.py
+++ b/pygaggle/data/unicode.py
@@ -1,0 +1,22 @@
+import unicodedata
+import six
+
+
+def convert_to_unicode(text):
+  """Converts `text` to Unicode (if it's not already), assuming utf-8 input."""
+  if six.PY3:
+    if isinstance(text, str):
+      return text
+    elif isinstance(text, bytes):
+      return text.decode("utf-8", "ignore")
+    else:
+      raise ValueError("Unsupported string type: %s" % (type(text)))
+  elif six.PY2:
+    if isinstance(text, str):
+      return text.decode("utf-8", "ignore")
+    elif isinstance(text, unicode):
+      return text
+    else:
+      raise ValueError("Unsupported string type: %s" % (type(text)))
+  else:
+    raise ValueError("Not running on Python2 or Python 3?")

--- a/pygaggle/model/decode.py
+++ b/pygaggle/model/decode.py
@@ -19,7 +19,10 @@ def greedy_decode(model: PreTrainedModel,
     past = model.get_encoder()(input_ids, attention_mask=attention_mask)
     next_token_logits = None
     for _ in range(length):
-        model_inputs = model.prepare_inputs_for_generation(decode_ids, past=past, attention_mask=attention_mask)
+        model_inputs = model.prepare_inputs_for_generation(decode_ids,
+                                                           past=past, 
+                                                           attention_mask=attention_mask, 
+                                                           use_cache=True)
         outputs = model(**model_inputs)  # (batch_size, cur_len, vocab_size)
         next_token_logits = outputs[0][:, -1, :]  # (batch_size, vocab_size)
         decode_ids = torch.cat([decode_ids, next_token_logits.max(1)[1].unsqueeze(-1)], dim=-1)

--- a/pygaggle/model/evaluate.py
+++ b/pygaggle/model/evaluate.py
@@ -100,6 +100,11 @@ class RecallAt3Metric(TopkMixin, RecallAccumulator):
     top_k = 3
 
 
+@register_metric('recall@1000')
+class RecallAt1000Metric(TopkMixin, RecallAccumulator):
+    top_k = 1000
+
+
 @register_metric('mrr')
 class MrrMetric(MeanAccumulator):
     def accumulate(self, scores: List[float], gold: RelevanceExample):
@@ -107,6 +112,13 @@ class MrrMetric(MeanAccumulator):
         rr = next((1 / (rank_idx + 1) for rank_idx, (idx, _) in enumerate(scores) if gold.labels[idx]), 0)
         self.scores.append(rr)
 
+
+@register_metric('mrr@10')
+class MrrAt10Metric(MeanAccumulator):
+    def accumulate(self, scores: List[float], gold: RelevanceExample):
+        scores = sorted(list(enumerate(scores)), key=lambda x: x[1], reverse=True)
+        rr = next((1 / (rank_idx + 1) for rank_idx, (idx, _) in enumerate(scores) if (gold.labels[idx] and rank_idx < 10)) 0)
+        self.scores.append(rr)
 
 class ThresholdedRecallMetric(DynamicThresholdingMixin, RecallAccumulator):
     threshold = 0.5

--- a/pygaggle/model/evaluate.py
+++ b/pygaggle/model/evaluate.py
@@ -100,6 +100,11 @@ class RecallAt3Metric(TopkMixin, RecallAccumulator):
     top_k = 3
 
 
+@register_metric('recall@50')
+class RecallAt50Metric(TopkMixin, RecallAccumulator):
+    top_k = 50
+
+
 @register_metric('recall@1000')
 class RecallAt1000Metric(TopkMixin, RecallAccumulator):
     top_k = 1000

--- a/pygaggle/model/evaluate.py
+++ b/pygaggle/model/evaluate.py
@@ -117,7 +117,7 @@ class MrrMetric(MeanAccumulator):
 class MrrAt10Metric(MeanAccumulator):
     def accumulate(self, scores: List[float], gold: RelevanceExample):
         scores = sorted(list(enumerate(scores)), key=lambda x: x[1], reverse=True)
-        rr = next((1 / (rank_idx + 1) for rank_idx, (idx, _) in enumerate(scores) if (gold.labels[idx] and rank_idx < 10)) 0)
+        rr = next((1 / (rank_idx + 1) for rank_idx, (idx, _) in enumerate(scores) if (gold.labels[idx] and rank_idx < 10)), 0)
         self.scores.append(rr)
 
 class ThresholdedRecallMetric(DynamicThresholdingMixin, RecallAccumulator):

--- a/pygaggle/rerank/base.py
+++ b/pygaggle/rerank/base.py
@@ -17,9 +17,12 @@ class Query:
     ----------
     text : str
         The query text.
+    id : Optional[str]
+        The query id.
     """
-    def __init__(self, text: str):
+    def __init__(self, text: str, id: Optional[str] = None):
         self.text = text
+        self.id = id
 
 
 class Text:

--- a/pygaggle/run/evaluate_kaggle_highlighter.py
+++ b/pygaggle/run/evaluate_kaggle_highlighter.py
@@ -16,10 +16,10 @@ from pygaggle.rerank.random import RandomReranker
 from pygaggle.rerank.similarity import CosineSimilarityMatrixProvider
 from pygaggle.model import SimpleBatchTokenizer, CachedT5ModelLoader, T5BatchTokenizer, RerankerEvaluator, metric_names
 from pygaggle.data import LitReviewDataset
-from pygaggle.settings import Settings
+from pygaggle.settings import Cord19Settings
 
 
-SETTINGS = Settings()
+SETTINGS = Cord19Settings()
 METHOD_CHOICES = ('transformer', 'bm25', 't5', 'seq_class_transformer', 'qa_transformer', 'random')
 
 

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -44,7 +44,6 @@ class PassageRankingEvaluationOptions(BaseModel):
         assert v.exists(), 'data directory must exist'
         return v
 
-    #TODO verify
     @validator('model_name')
     def model_name_sane(cls, v: Optional[str], values, **kwargs):
         method = values['method']
@@ -58,7 +57,6 @@ class PassageRankingEvaluationOptions(BaseModel):
             return SETTINGS.monobert_dir
         return v
 
-    #TODO verify
     @validator('tokenizer_name')
     def tokenizer_sane(cls, v: str, values, **kwargs):
         if v is None:
@@ -78,7 +76,7 @@ def construct_t5(options: PassageRankingEvaluationOptions) -> Reranker:
     tokenizer = T5BatchTokenizer(tokenizer, options.batch_size)
     return T5Reranker(model, tokenizer)
 
-#TODO needed?
+
 def construct_transformer(options: PassageRankingEvaluationOptions) -> Reranker:
     device = torch.device(options.device)
     try:

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -1,0 +1,149 @@
+from typing import Optional, List
+from pathlib import Path
+import logging
+
+from pydantic import BaseModel, validator
+from transformers import AutoModel, AutoTokenizer, AutoModelForSequenceClassification, BertForQuestionAnswering, \
+    BertForSequenceClassification
+import torch
+
+from .args import ArgumentParserBuilder, opt
+from pygaggle.rerank.base import Reranker
+from pygaggle.rerank.bm25 import Bm25Reranker
+from pygaggle.rerank.transformer import UnsupervisedTransformerReranker, T5Reranker, \
+    SequenceClassificationTransformerReranker, QuestionAnsweringTransformerReranker
+from pygaggle.rerank.random import RandomReranker
+from pygaggle.rerank.similarity import CosineSimilarityMatrixProvider
+from pygaggle.model import SimpleBatchTokenizer, CachedT5ModelLoader, T5BatchTokenizer, RerankerEvaluator, metric_names
+from pygaggle.data import LitReviewDataset
+from pygaggle.settings import Settings
+
+
+SETTINGS = Settings()
+METHOD_CHOICES = ('transformer', 'bm25', 't5', 'seq_class_transformer', 'random')
+
+
+class PassageRankingEvaluationOptions(BaseModel):
+    dataset: Path
+    method: str
+    batch_size: int
+    device: str
+    split: str
+    do_lower_case: bool
+    is_duo: bool
+    metrics: List[str]
+    model_name: Optional[str]
+    tokenizer_name: Optional[str]
+
+    @validator('dataset')
+    def dataset_exists(cls, v: Path):
+        assert v in ['msmarco', 'treccar']
+
+    @validator('data-dir')
+        assert v.exists(), 'dataset must exist'
+        return v
+
+    #TODO verify
+    @validator('model_name')
+    def model_name_sane(cls, v: Optional[str], values, **kwargs):
+        method = values['method']
+        if method == 'transformer' and v is None:
+            raise ValueError('transformer name must be specified')
+        elif method == 't5':
+            return SETTINGS.t5_model_type
+        if v == 'biobert':
+            return 'monologg/biobert_v1.1_pubmed'
+        return v
+
+    #TODO verify
+    @validator('tokenizer_name')
+    def tokenizer_sane(cls, v: str, values, **kwargs):
+        if v is None:
+            return values['model_name']
+        return v
+
+
+def construct_t5(options: KaggleEvaluationOptions) -> Reranker:
+    loader = CachedT5ModelLoader(SETTINGS.t5_model_dir,
+                                 SETTINGS.cache_dir,
+                                 'ranker',
+                                 SETTINGS.t5_model_type,
+                                 SETTINGS.flush_cache)
+    device = torch.device(options.device)
+    model = loader.load().to(device).eval()
+    tokenizer = AutoTokenizer.from_pretrained(options.model_name, do_lower_case=options.do_lower_case)
+    tokenizer = T5BatchTokenizer(tokenizer, options.batch_size)
+    return T5Reranker(model, tokenizer)
+
+#TODO needed?
+def construct_transformer(options: KaggleEvaluationOptions) -> Reranker:
+    device = torch.device(options.device)
+    try:
+        model = AutoModel.from_pretrained(options.model_name).to(device).eval()
+    except OSError:
+        model = AutoModel.from_pretrained(options.model_name, from_tf=True).to(device).eval()
+    tokenizer = SimpleBatchTokenizer(AutoTokenizer.from_pretrained(options.tokenizer_name,
+                                                                   do_lower_case=options.do_lower_case),
+                                     options.batch_size)
+    provider = CosineSimilarityMatrixProvider() 
+    return UnsupervisedTransformerReranker(model, tokenizer, provider)
+
+
+def construct_seq_class_transformer(options: KaggleEvaluationOptions) -> Reranker:
+    try:
+        model = AutoModelForSequenceClassification.from_pretrained(options.model_name)
+    except OSError:
+        try:
+            model = AutoModelForSequenceClassification.from_pretrained(options.model_name, from_tf=True)
+        except AttributeError:
+            # Hotfix for BioBERT MS MARCO. Refactor.
+            BertForSequenceClassification.bias = torch.nn.Parameter(torch.zeros(2))
+            BertForSequenceClassification.weight = torch.nn.Parameter(torch.zeros(2, 768))
+            model = BertForSequenceClassification.from_pretrained(options.model_name, from_tf=True)
+            model.classifier.weight = BertForSequenceClassification.weight
+            model.classifier.bias = BertForSequenceClassification.bias
+    device = torch.device(options.device)
+    model = model.to(device).eval()
+    tokenizer = AutoTokenizer.from_pretrained(options.tokenizer_name, do_lower_case=options.do_lower_case)
+    return SequenceClassificationTransformerReranker(model, tokenizer)
+
+
+def construct_bm25(_: KaggleEvaluationOptions) -> Reranker:
+    return Bm25Reranker(index_path=SETTINGS.cord19_index_path)
+
+
+def main():
+    apb = ArgumentParserBuilder()
+    apb.add_opts(opt('--dataset', type=str, default='msmarco'),
+                 opt('--data-dir', type=Path, default='data/kaggle-lit-review-0.1.json'),
+                 opt('--method', required=True, type=str, choices=METHOD_CHOICES),
+                 opt('--model-name', type=str),
+                 opt('--split', type=str, default='nq', choices=('dev', 'eval')),
+                 opt('--batch-size', '-bsz', type=int, default=96),
+                 opt('--device', type=str, default='cuda:0'),
+                 opt('--tokenizer-name', type=str),
+                 opt('--do-lower-case', action='store_true'),
+                 opt('--is-duo', action='store_true'),
+                 opt('--metrics', type=str, nargs='+', default=metric_names(), choices=metric_names()))
+    args = apb.parser.parse_args()
+    options = PassageRankingEvaluationOptions(**vars(args))
+    ds = LitReviewDataset.from_file(str(options.dataset))
+    examples = ds.to_senticized_dataset(SETTINGS.cord19_index_path, split=options.split)
+    construct_map = dict(transformer=construct_transformer,
+                         bm25=construct_bm25,
+                         t5=construct_t5,
+                         seq_class_transformer=construct_seq_class_transformer,
+                         qa_transformer=construct_qa_transformer,
+                         random=lambda _: RandomReranker())
+    reranker = construct_map[options.method](options)
+    evaluator = RerankerEvaluator(reranker, options.metrics)
+    width = max(map(len, args.metrics)) + 1
+    stdout = []
+    for metric in evaluator.evaluate(examples):
+        logging.info(f'{metric.name:<{width}}{metric.value:.5}')
+        stdout.append(f'{metric.name}\t{metric.value}')
+    print('\n'.join(stdout))
+
+
+if __name__ == '__main__':
+    main()

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List
 from pathlib import Path
 import logging
 
@@ -26,7 +26,7 @@ class PassageRankingEvaluationOptions(BaseModel):
     dataset: str
     data_dir: Path
     method: str
-    model_name_or_path: Optional[Union[str, Path]]
+    model_name_or_path: str
     split: str
     batch_size: int
     device: str
@@ -121,7 +121,7 @@ def main():
     apb.add_opts(opt('--dataset', type=str, default='msmarco'),
                  opt('--data-dir', type=Path, default='/content/data/msmarco'),
                  opt('--method', required=True, type=str, choices=METHOD_CHOICES),
-                 opt('--model-name-or-path', type=Union[str,Path]),
+                 opt('--model-name-or-path', type=str),
                  opt('--split', type=str, default='dev', choices=('dev', 'eval')),
                  opt('--batch-size', '-bsz', type=int, default=96),
                  opt('--device', type=str, default='cuda:0'),

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -23,7 +23,7 @@ METHOD_CHOICES = ('transformer', 'bm25', 't5', 'seq_class_transformer', 'random'
 
 
 class PassageRankingEvaluationOptions(BaseModel):
-    dataset: Path
+    dataset: str
     data_dir: Path
     method: str
     batch_size: int
@@ -132,7 +132,7 @@ def main():
     args = apb.parser.parse_args()
     options = PassageRankingEvaluationOptions(**vars(args))
     ds = MsMarcoDataset.from_folder(str(options.data_dir), split=options.split, is_duo=options.is_duo)
-    examples = ds.to_relevance_examples(SETTINGS.msmarco_index_path, split=options.split, is_duo=options.is_duo)
+    examples = ds.to_relevance_examples(SETTINGS.msmarco_index_path, is_duo=options.is_duo)
     construct_map = dict(transformer=construct_transformer,
                          bm25=construct_bm25,
                          t5=construct_t5,

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -107,7 +107,8 @@ def construct_seq_class_transformer(options: PassageRankingEvaluationOptions) ->
             model.classifier.bias = BertForSequenceClassification.bias
     device = torch.device(options.device)
     model = model.to(device).eval()
-    tokenizer = AutoTokenizer.from_pretrained(options.tokenizer_name, do_lower_case=options.do_lower_case)
+    tokenizer = AutoTokenizer.from_pretrained(options.tokenizer_name, 
+                                              do_lower_case=options.do_lower_case)
     return SequenceClassificationTransformerReranker(model, tokenizer)
 
 

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -54,11 +54,8 @@ class PassageRankingEvaluationOptions(BaseModel):
     @validator('model_name_or_path')
     def model_name_sane(cls, v: Optional[str], values, **kwargs):
         method = values['method']
-        model_type = values['model_type']
         if method == 'transformer' and v is None:
-            raise ValueError('transformer name must be specified')
-        elif method == 't5':
-            assert method in model_type
+            raise ValueError('transformer name or path must be specified')
         return v
 
     @validator('tokenizer_name')
@@ -76,7 +73,7 @@ def construct_t5(options: PassageRankingEvaluationOptions) -> Reranker:
                                  SETTINGS.flush_cache)
     device = torch.device(options.device)
     model = loader.load().to(device).eval()
-    tokenizer = AutoTokenizer.from_pretrained(options.model_name_or_path)
+    tokenizer = AutoTokenizer.from_pretrained(options.model_type)
     tokenizer = T5BatchTokenizer(tokenizer, options.batch_size)
     return T5Reranker(model, tokenizer)
 

--- a/pygaggle/settings.py
+++ b/pygaggle/settings.py
@@ -18,7 +18,7 @@ class MsMarcoSettings(Settings):
     msmarco_index_path: str = '/content/data/index-msmarco-passage-20191117-0ed488'
 
     # T5 model settings
-    t5_model_dir: str = '/content/models/t5'
+    t5_model_dir: str = 'gs://neuralresearcher_data/doc2query/experiments/367'
 
     # monoBERT model settings
     monobert_dir: str = '/content/models/monobert_msmarco_large'

--- a/pygaggle/settings.py
+++ b/pygaggle/settings.py
@@ -5,28 +5,17 @@ from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
-    # T5 model settings
-    t5_model_type: str = 't5-base'
-    t5_max_length: int = 512
-
     # Cache settings
     cache_dir: Path = Path(os.getenv('XDG_CACHE_HOME', str(Path.home() / '.cache'))) / 'covidex'
     flush_cache: bool = False
 
 
 class MsMarcoSettings(Settings):
-    msmarco_index_path: str = '/content/data/index-msmarco-passage-20191117-0ed488'
-
-    # T5 model settings
-    t5_model_dir: str = 'gs://neuralresearcher_data/doc2query/experiments/367'
-
-    # monoBERT model settings
-    monobert_dir: str = '/content/models/monobert_msmarco_large'
-    monobert_model_type: str = 'bert-large'
-
+    msmarco_index_path: str = 'data/index-msmarco-passage-20191117-0ed488'
 
 class Cord19Settings(Settings):
     cord19_index_path: str = 'data/lucene-index-covid-paragraph'
     
     # T5 model settings
     t5_model_dir: str = 'gs://neuralresearcher_data/covid/data/model_exp304'
+    t5_model_type: str = 't5-base'

--- a/pygaggle/settings.py
+++ b/pygaggle/settings.py
@@ -25,10 +25,8 @@ class MsMarcoSettings(Settings):
     monobert_model_type: str = 'bert-large'
 
 
-
-
 class Cord19Settings(Settings):
-	cord19_index_path: str = 'data/lucene-index-covid-paragraph'
-
+    cord19_index_path: str = 'data/lucene-index-covid-paragraph'
+    
     # T5 model settings
     t5_model_dir: str = 'gs://neuralresearcher_data/covid/data/model_exp304'

--- a/pygaggle/settings.py
+++ b/pygaggle/settings.py
@@ -5,13 +5,30 @@ from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
-    cord19_index_path: str = 'data/lucene-index-covid-paragraph'
-
     # T5 model settings
-    t5_model_dir: str = 'gs://neuralresearcher_data/covid/data/model_exp304'
     t5_model_type: str = 't5-base'
     t5_max_length: int = 512
 
     # Cache settings
     cache_dir: Path = Path(os.getenv('XDG_CACHE_HOME', str(Path.home() / '.cache'))) / 'covidex'
     flush_cache: bool = False
+
+
+class MsMarcoSettings(Settings):
+    msmarco_index_path: str = '/content/data/index-msmarco-passage-20191117-0ed488'
+
+    # T5 model settings
+    t5_model_dir: str = '/content/models/t5'
+
+    # monoBERT model settings
+    monobert_dir: str = '/content/models/monobert_msmarco_large'
+    monobert_model_type: str = 'bert-large'
+
+
+
+
+class Cord19Settings(Settings):
+	cord19_index_path: str = 'data/lucene-index-covid-paragraph'
+
+    # T5 model settings
+    t5_model_dir: str = 'gs://neuralresearcher_data/covid/data/model_exp304'

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ with open('README.md') as fh:
     long_description = fh.read()
 
 reqs = [
+    'dataclasses;python_version<"3.7"',
     'coloredlogs==14.0',
     'numpy==1.18.2',
     'pydantic==1.5',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'tensorflow>=2.2.0rc1',
     'tokenizers==0.5.2',
     'tqdm==4.45.0',
-    'transformers==2.7.0'
+    'transformers>=2.7.0'
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ reqs = [
     'tensorflow>=2.2.0rc1',
     'tokenizers>=0.5.2',
     'tqdm==4.45.0',
-    'transformers>=2.7.0'
+    'transformers==2.8.0'
 ]
 
 setuptools.setup(
@@ -25,7 +25,7 @@ setuptools.setup(
     version='0.0.1',
     author='PyGaggle Gaggle',
     author_email='r33tang@uwaterloo.ca',
-    description='A gaggle of rerankers for CovidQA and CORD-19',
+    description='A gaggle of rerankers for CovidQA, CORD-19 and MS-MARCO',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/castorini/pygaggle',

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ reqs = [
     'spacy==2.2.4',
     'tensorboard>=2.1.0',
     'tensorflow>=2.2.0rc1',
-    'tokenizers==0.5.2',
+    'tokenizers>=0.5.2',
     'tqdm==4.45.0',
     'transformers>=2.7.0'
 ]


### PR DESCRIPTION
Tested on a subset of 50 questions (1000 passages each) on colab (P100): https://colab.research.google.com/drive/1C-0U40wCUbDUObWReBYkeIBLgqJeKCuO

It takes about 16-17 minutes. So can potentially scale it up to 1000ish examples when having URAs replicate it. I will also entirely replicate the results entirely across multiple GPUs/TPUs as and when I add support for it!

m̶r̶r̶@̶1̶0̶ ̶0̶.̶3̶6̶4̶7̶6̶9̶8̶4̶1̶2̶6̶9̶8̶4̶1̶3̶ ̶v̶s̶ ̶@̶r̶o̶d̶r̶i̶g̶o̶n̶o̶g̶u̶e̶i̶r̶a̶4̶'̶s̶ ̶r̶u̶n̶.̶m̶o̶n̶o̶b̶e̶r̶t̶.̶d̶e̶v̶.̶s̶m̶a̶l̶l̶.̶t̶s̶v̶ ̶s̶c̶o̶r̶i̶n̶g̶ ̶m̶r̶r̶@̶1̶0̶:̶ ̶0̶.̶3̶5̶7̶6̶9̶0̶4̶7̶6̶1̶9̶0̶4̶7̶6̶3̶ ̶o̶n̶ ̶t̶h̶e̶s̶e̶ ̶5̶0̶ ̶q̶u̶e̶s̶t̶i̶o̶n̶s̶.̶ ̶(there was something wrong with the sample, reinvestigating now) This is potentially due to the tokenization difference (here we just use encode_plus that follows ’longest_first’ truncation strategy vs fixed length tokenization of 64 tokens for the query and 448 for the passage). It could also be due to a bunch of other things as we saw similar differences in numbert. 

Some other important general changes I made:
1. python>=3.6 instead of 3.7 (Colab right now uses 3.6). 
2. Refactored Settings (in settings.py).
3. Added type Optional[str] field id to base class Query.
4. Update to newer transformers/tokenizers