### PR TITLE
Fix submodule name to be consistent with pyserini, minor changes to get it to work

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "eval"]
-	path = eval/
+	path = eval
 	url = https://github.com/castorini/anserini-eval.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "eval"]
 	path = eval
-	url = https://github.com/castorini/anserini-eval.git
+	url = git@github.com:castorini/anserini-eval.git


### PR DESCRIPTION
Rename, change `eval/` to `eval` in the path. Seems to only work for me if I do this