### PR TITLE
CovidQA + MSMARCO doc Replication log

### DIFF
--- a/docs/experiments-CovidQA.md
+++ b/docs/experiments-CovidQA.md
@@ -149,4 +149,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 
 ## Replication Log
 
-Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4, Tesla P100)
+Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab, Tesla P100 on Colab)

--- a/docs/experiments-CovidQA.md
+++ b/docs/experiments-CovidQA.md
@@ -149,4 +149,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 
 ## Replication Log
 
-Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (T4)
+Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4)

--- a/docs/experiments-CovidQA.md
+++ b/docs/experiments-CovidQA.md
@@ -149,3 +149,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 
 ## Replication Log
 
+Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (T4)

--- a/docs/experiments-CovidQA.md
+++ b/docs/experiments-CovidQA.md
@@ -149,4 +149,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 
 ## Replication Log
 
-Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4)
+Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4, Tesla P100)

--- a/docs/experiments-msmarco-document.md
+++ b/docs/experiments-msmarco-document.md
@@ -118,3 +118,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 
 + Results replicated by [@HangCui0510](https://github.com/HangCui0510) on 2020-07-08 (commit [`f2e078e`](https://github.com/HangCui0510/pygaggle/commit/f2e078e47c87156925a9151632753be861ec403d)) (Tesla P100)
 + Results replicated by [@mrkarezina](https://github.com/mrkarezina) on 2020-07-20 (commit [`c1a54cb`](https://github.com/castorini/pygaggle/commit/c1a54cb012a1d4ea24a2ce2bc24298417279a9c4)) (Tesla T4)
++ Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-09 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab)


### PR DESCRIPTION
CovidQA: All identical except for BM25
MS-MARCO doc: Identical
See comments for detailed replication results