### PR TITLE
Add replication logs for MSMARCO passage, document and CovidQA.

### DIFF
--- a/docs/experiments-CovidQA.md
+++ b/docs/experiments-CovidQA.md
@@ -152,3 +152,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 
 + Results replicated by [@justinborromeo](https://github.com/justinborromeo) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (GTX960M)
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab, Tesla P100 on Colab)
++ Results replicated by [@LizzyZhang-tutu](https://github.com/LizzyZhang-tutu) on 2020-09-09 (commit[`8eeefa5`](https://github.com/castorini/pygaggle/commit/8eeefa578c65e2da78be129c87dfb40beb74099c)) (Tesla T4 on Colab)

--- a/docs/experiments-msmarco-document.md
+++ b/docs/experiments-msmarco-document.md
@@ -120,3 +120,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@mrkarezina](https://github.com/mrkarezina) on 2020-07-20 (commit [`c1a54cb`](https://github.com/castorini/pygaggle/commit/c1a54cb012a1d4ea24a2ce2bc24298417279a9c4)) (Tesla T4)
 + Results replicated by [@justinborromeo](https://github.com/justinborromeo) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (GTX960M)
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-09 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab)
++ Results replicated by [@LizzyZhang-tutu](https://github.com/LizzyZhang-tutu) on 2020-09-09 (commit[`8eeefa5`](https://github.com/castorini/pygaggle/commit/8eeefa578c65e2da78be129c87dfb40beb74099c)) (Tesla T4 on Colab)

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -163,3 +163,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@mrkarezina](https://github.com/mrkarezina) on 2020-07-19 (commit [`c1a54cb`](https://github.com/castorini/pygaggle/commit/c1a54cb012a1d4ea24a2ce2bc24298417279a9c4)) (Tesla T4)
 + Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-08 (commit [`94befbd`](https://github.com/qguo96/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab)
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab)
++ Results replicated by [@LizzyZhang-tutu](https://github.com/LizzyZhang-tutu) on 2020-09-09 (commit[`8eeefa5`](https://github.com/castorini/pygaggle/commit/8eeefa578c65e2da78be129c87dfb40beb74099c)) (Tesla T4 on Colab)


### PR DESCRIPTION
**Colab Environment**

> OS: macOS Catalina Version 10.15.5 (19F101)
> Java: openjdk 11.0.8 2020-07-14
> Python: Python 3.6.9
> GPU: Tesla T4 on Colab

**Replication Results**
> all Identical

**Time taken**
MS MARCO Passage Retrieval:

> monoBERT: 51:25
> monoT5: 37:29

MS MARCO Document Retrieval:

> monoT5 
> first half: 3:56:53
> second half: 4:15:11

CovidQA:
> Random: <1s
> BM25: 9s
> monoT5: 16:05

Issue encountered:
CovidQA replication doc: https://github.com/castorini/pygaggle/blob/master/docs/experiments-CovidQA.md does not have a Data Prep section as https://github.com/castorini/pygaggle/blob/daeb78c8d020112a7824dfd4d487905860372892/docs/experiments-msmarco-passage.md#data-prep, I simply ran the script `sh scripts/update-index.sh` to get the data.