### PR TITLE
replication results for MSMARCO document and CovidQA.

### DIFF
--- a/docs/experiments-CovidQA.md
+++ b/docs/experiments-CovidQA.md
@@ -153,3 +153,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@justinborromeo](https://github.com/justinborromeo) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (GTX960M)
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab, Tesla P100 on Colab)
 + Results replicated by [@LizzyZhang-tutu](https://github.com/LizzyZhang-tutu) on 2020-09-09 (commit[`8eeefa5`](https://github.com/castorini/pygaggle/commit/8eeefa578c65e2da78be129c87dfb40beb74099c)) (Tesla T4 on Colab)
++ Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-10 (commit[`a1461f5`](https://github.com/castorini/pygaggle/commit/a1461f5e6bd7c2c5fd00d3586d9eef735d978f06)) (Tesla T4 on Colab)

--- a/docs/experiments-msmarco-document.md
+++ b/docs/experiments-msmarco-document.md
@@ -121,3 +121,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@justinborromeo](https://github.com/justinborromeo) on 2020-09-08 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (GTX960M)
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-09 (commit[`94befbd`](https://github.com/castorini/pygaggle/commit/94befbd58b19c3e46d930e67797102bf174efd01)) (Tesla T4 on Colab)
 + Results replicated by [@LizzyZhang-tutu](https://github.com/LizzyZhang-tutu) on 2020-09-09 (commit[`8eeefa5`](https://github.com/castorini/pygaggle/commit/8eeefa578c65e2da78be129c87dfb40beb74099c)) (Tesla T4 on Colab)
++ Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-10 (commit[`a1461f5`](https://github.com/castorini/pygaggle/commit/a1461f5e6bd7c2c5fd00d3586d9eef735d978f06)) (Tesla K80 on Colab)


### PR DESCRIPTION
Finally, replication on Colab through ssh is successful with K80 ....

Colab Environment:
OS: Ubuntu-18.04.3 LTS
Java: 11.0.8
Python: 3.6.9

results are shown below:

+ experiments-msmarco-document(identical with the documents):
     Re-Ranking with monoT5:
     First half:
     
![Screenshot (1168)](https://user-images.githubusercontent.com/30187452/92812963-46fb4780-f38e-11ea-8154-09cb3f45e1c6.png)
     Second half:
![Screenshot (1175)](https://user-images.githubusercontent.com/30187452/92812973-5084af80-f38e-11ea-956a-b82f8dfd2f39.png)


+ experiments-CovidQA(identical with the documents):
     Re-Ranking with Random:
     NL Question:
![Screenshot (1177)](https://user-images.githubusercontent.com/30187452/92813184-bb35eb00-f38e-11ea-94d2-7591071e1b04.png)

     Keyword Query:
![Screenshot (1178)](https://user-images.githubusercontent.com/30187452/92813195-bec97200-f38e-11ea-8237-6cd7dea406f7.png)

     Re-Ranking with BM25:
     NL Question:
![Screenshot (1179)](https://user-images.githubusercontent.com/30187452/92813313-f506f180-f38e-11ea-9724-d6aebc0a0a68.png)

     Keyword Query:
![Screenshot (1180)](https://user-images.githubusercontent.com/30187452/92813329-fafcd280-f38e-11ea-8105-2615de6f3c13.png)

     Re-Ranking with monoT5:
     NL Question:
![Screenshot (1182)](https://user-images.githubusercontent.com/30187452/92813463-313a5200-f38f-11ea-92ea-e189b37ff301.png)

     Keyword Query:
![Screenshot (1184)](https://user-images.githubusercontent.com/30187452/92813470-34354280-f38f-11ea-91d0-b491e26b7e4b.png)



