### PR TITLE
Adds links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ reranked.sort(key=lambda x: x.score, reverse=True)
 for i in range(0, 10):
     print(f'{i+1:2} {reranked[i].metadata["docid"]:15} {reranked[i].score:.5f} {reranked[i].text}')
 ```
+
+## Experiments on IR collections
+
+The following documents describe how to use Pygaggle on various IR test collections:
+
++ [Experiments on CovidQA](https://github.com/castorini/pygaggle/blob/master/docs/experiments-CovidQA.md)
++ [Experiments on MS MARCO Document Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-document.md)
++ [Experiments on MS MARCO Passage Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-passage.md)


### PR DESCRIPTION
I realized we don't have any pointers to MS MARCO and CovidQA documentations on the main page.