### PR TITLE
Update Replication Log and Refactor Instructions for MS Marco Passage Retreival - Entire Dev Set 

### DIFF
--- a/docs/experiments-msmarco-passage-entire.md
+++ b/docs/experiments-msmarco-passage-entire.md
@@ -35,9 +35,16 @@ Then load Java module:
 module load java
 ```
 Then install Pytorch.
-Then install PyGaggle by the following commend.
 ```
-pip install -r requirement.txt
+pip install torch
+```
+Then install PyGaggle by the following command.
+```
+pip install -r requirements.txt
+```
+Note: On Compute Canada, you may have to install tensorflow separately by the following command.
+```
+pip install tensorflow_gpu 
 ```
 
 ## Models
@@ -169,3 +176,4 @@ Please mention in your PR if you find any difference!
 
 + Results replicated by [@qguo96](https://github.com/qguo96) on 2020-10-08 (commit [`3d4b7c0`](https://github.com/castorini/pygaggle/commit/3d4b7c0a51b5b26e5d39da7c7b9c0cec8e633950)) (Tesla V100 on Compute Canada)
 + Results replicated by [@stephaniewhoo](https://github.com/stephaniewhoo) on 2020-10-25 (commit[`e815051`](https://github.com/castorini/pygaggle/commit/e815051f2cee1af98b370ee030b66c07a8a287f3)) (Tesla V100 on Compute Canada)
++ Results replicated by [@rayyang29](https://github.com/rayyang29) on 2020-11-16 (commit[`d840b0c`](https://github.com/castorini/pygaggle/commit/d840b0c0fc2a5a0a6e10f87c94b31824964449f7))(Tesla V100 on Compute Canada)


### PR DESCRIPTION
Compute Canada environment: 
OS: linux CentOS-7
Java 13.0.1
Python 3.6.3 
**Re-Ranking with monoBERT** 
`2020-11-13 14:36:43 [INFO] evaluate_passage_ranker: Reranking:` 
`100%|██████████| 6980/6980 [63:20:00<00:00, 32.66s/it]` 
`2020-11-16 05:56:44 [INFO] evaluate_passage_ranker: precision@1 0.2533` 
`2020-11-16 05:56:44 [INFO] evaluate_passage_ranker: recall@3    0.45093` 
`2020-11-16 05:56:44 [INFO] evaluate_passage_ranker: recall@50   0.80609` 
`2020-11-16 05:56:44 [INFO] evaluate_passage_ranker: recall@1000 0.86289` 
`2020-11-16 05:56:44 [INFO] evaluate_passage_ranker: mrr         0.38789` 
`2020-11-16 05:56:44 [INFO] evaluate_passage_ranker: mrr@10      0.37922` 

**Re-Ranking with monoT5** 
`2020-11-13 14:46:35 [INFO] evaluate_passage_ranker: Reranking:` 
`100%|██████████| 6980/6980 [26:50:07<00:00, 13.84s/it]` 
`2020-11-14 17:36:42 [INFO] evaluate_passage_ranker: precision@1 0.25129` 
`2020-11-14 17:36:42 [INFO] evaluate_passage_ranker: recall@3    0.45362` 
`2020-11-14 17:36:42 [INFO] evaluate_passage_ranker: recall@50   0.80709` 
`2020-11-14 17:36:42 [INFO] evaluate_passage_ranker: recall@1000 0.86289` 
`2020-11-14 17:36:42 [INFO] evaluate_passage_ranker: mrr         0.38839` 
`2020-11-14 17:36:42 [INFO] evaluate_passage_ranker: mrr@10      0.37986` 

I have also slightly refactored the instructions for MS Marco Entire. I've fixed some typos and added a note clarifying the installing of tensorflow on CC with the instruction: `pip install tensorflow_gpu`