### PR TITLE
fix inconsistency re upgrading to transformer 4.0.0 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
     - tokenizers==0.9.4
     - tqdm==4.45.0
     - transformers==4.0.0
+    - sentencepiece==0.1.94

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,6 @@ dependencies:
     - spacy==2.2.4
     - tensorboard>=2.1.0
     - tensorflow>=2.2.0rc1
-    - tokenizers==0.7
+    - tokenizers==0.9.4
     - tqdm==4.45.0
-    - transformers==2.10.0
+    - transformers==4.0.0

--- a/pygaggle/model/decode.py
+++ b/pygaggle/model/decode.py
@@ -17,12 +17,13 @@ def greedy_decode(model: PreTrainedModel,
     decode_ids = torch.full((input_ids.size(0), 1),
                             model.config.decoder_start_token_id,
                             dtype=torch.long).to(input_ids.device)
-    past = model.get_encoder()(input_ids, attention_mask=attention_mask)
+    encoder_outputs = model.get_encoder()(input_ids, attention_mask=attention_mask)
     next_token_logits = None
     for _ in range(length):
         model_inputs = model.prepare_inputs_for_generation(
             decode_ids,
-            past=past,
+            encoder_outputs=encoder_outputs,
+            past=None,
             attention_mask=attention_mask,
             use_cache=True)
         outputs = model(**model_inputs)  # (batch_size, cur_len, vocab_size)

--- a/pygaggle/model/tokenize.py
+++ b/pygaggle/model/tokenize.py
@@ -110,7 +110,8 @@ class T5BatchTokenizer(AppendEosTokenizerMixin, QueryDocumentBatchTokenizer):
     def __init__(self, *args, **kwargs):
         kwargs['pattern'] = 'Query: {query} Document: {document} Relevant:'
         kwargs['return_attention_mask'] = True
-        kwargs['pad_to_max_length'] = True
+        kwargs['padding'] = 'max_length'
+        kwargs["truncation"] = True
         kwargs['return_tensors'] = 'pt'
         kwargs['max_length'] = 512
         super().__init__(*args, **kwargs)
@@ -119,7 +120,8 @@ class T5BatchTokenizer(AppendEosTokenizerMixin, QueryDocumentBatchTokenizer):
 class SimpleBatchTokenizer(BatchTokenizer):
     def __init__(self, *args, **kwargs):
         kwargs['return_attention_mask'] = True
-        kwargs['pad_to_max_length'] = True
+        kwargs['padding'] = 'max_length'
+        kwargs['truncation'] = True
         super().__init__(*args, **kwargs)
 
 

--- a/pygaggle/model/tokenize.py
+++ b/pygaggle/model/tokenize.py
@@ -110,7 +110,7 @@ class T5BatchTokenizer(AppendEosTokenizerMixin, QueryDocumentBatchTokenizer):
     def __init__(self, *args, **kwargs):
         kwargs['pattern'] = 'Query: {query} Document: {document} Relevant:'
         kwargs['return_attention_mask'] = True
-        kwargs['padding'] = 'max_length'
+        kwargs['padding'] = 'longest'
         kwargs["truncation"] = True
         kwargs['return_tensors'] = 'pt'
         kwargs['max_length'] = 512

--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -43,7 +43,7 @@ class MonoT5(Reranker):
     def get_tokenizer(pretrained_model_name_or_path: str = 't5-base',
                       *args, batch_size: int = 8, **kwargs) -> T5BatchTokenizer:
         return T5BatchTokenizer(
-            AutoTokenizer.from_pretrained(pretrained_model_name_or_path, *args, **kwargs),
+            AutoTokenizer.from_pretrained(pretrained_model_name_or_path, use_fast=False, *args, **kwargs),
             batch_size=batch_size
         )
 
@@ -132,7 +132,7 @@ class MonoBERT(Reranker):
     @staticmethod
     def get_tokenizer(pretrained_model_name_or_path: str = 'bert-large-uncased',
                       *args, **kwargs) -> AutoTokenizer:
-        return AutoTokenizer.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        return AutoTokenizer.from_pretrained(pretrained_model_name_or_path, use_fast=False, *args, **kwargs)
 
     @torch.no_grad()
     def rerank(self, query: Query, texts: List[Text]) -> List[Text]:

--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -141,11 +141,12 @@ class MonoBERT(Reranker):
             ret = self.tokenizer.encode_plus(query.text,
                                              text.text,
                                              max_length=512,
+                                             truncation=True,
                                              return_token_type_ids=True,
                                              return_tensors='pt')
             input_ids = ret['input_ids'].to(self.device)
             tt_ids = ret['token_type_ids'].to(self.device)
-            output, = self.model(input_ids, token_type_ids=tt_ids)
+            output, = self.model(input_ids, token_type_ids=tt_ids, return_dict=False)
             if output.size(1) > 1:
                 text.score = torch.nn.functional.log_softmax(
                                 output, 1)[0, -1].item()
@@ -167,12 +168,14 @@ class QuestionAnsweringTransformerReranker(Reranker):
             ret = self.tokenizer.encode_plus(query.text,
                                              text.text,
                                              max_length=512,
+                                             truncation=True,
                                              return_tensors='pt',
                                              return_token_type_ids=True)
             input_ids = ret['input_ids'].to(self.device)
             tt_ids = ret['token_type_ids'].to(self.device)
             start_scores, end_scores = self.model(input_ids,
-                                                  token_type_ids=tt_ids)
+                                                  token_type_ids=tt_ids,
+                                                  return_dict=False)
             start_scores = start_scores[0]
             end_scores = end_scores[0]
             start_scores[(1 - tt_ids[0]).bool()] = -5000

--- a/pygaggle/run/evaluate_document_ranker.py
+++ b/pygaggle/run/evaluate_document_ranker.py
@@ -93,7 +93,7 @@ def construct_transformer(options:
     model = AutoModel.from_pretrained(options.model,
                                       from_tf=options.from_tf).to(device).eval()
     tokenizer = SimpleBatchTokenizer(AutoTokenizer.from_pretrained(
-        options.tokenizer_name),
+        options.tokenizer_name, use_fast=False,),
         options.batch_size)
     provider = CosineSimilarityMatrixProvider()
     return UnsupervisedTransformerReranker(model, tokenizer, provider)

--- a/pygaggle/run/evaluate_kaggle_highlighter.py
+++ b/pygaggle/run/evaluate_kaggle_highlighter.py
@@ -139,7 +139,9 @@ def construct_qa_transformer(options: KaggleEvaluationOptions) -> Reranker:
     device = torch.device(options.device)
     model = model.to(device).eval()
     tokenizer = AutoTokenizer.from_pretrained(
-                    options.tokenizer_name, do_lower_case=options.do_lower_case)
+                    options.tokenizer_name, 
+                    do_lower_case=options.do_lower_case,
+                    use_fast=False)
     return QuestionAnsweringTransformerReranker(model, tokenizer)
 
 

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -91,7 +91,7 @@ def construct_transformer(options:
     model = AutoModel.from_pretrained(options.model,
                                       from_tf=options.from_tf).to(device).eval()
     tokenizer = SimpleBatchTokenizer(AutoTokenizer.from_pretrained(
-        options.tokenizer_name),
+        options.tokenizer_name, use_fast=False),
         options.batch_size)
     provider = CosineSimilarityMatrixProvider()
     return UnsupervisedTransformerReranker(model, tokenizer, provider)

--- a/pygaggle/run/evaluate_trec_covid_ranker.py
+++ b/pygaggle/run/evaluate_trec_covid_ranker.py
@@ -80,7 +80,7 @@ def construct_t5(options: DocumentRankingEvaluationOptions) -> Reranker:
     device = torch.device(options.device)
     model = T5ForConditionalGeneration.from_pretrained(options.model,
                                                        from_tf=options.from_tf).to(device).eval()
-    tokenizer = AutoTokenizer.from_pretrained(options.model_type)
+    tokenizer = AutoTokenizer.from_pretrained(options.model_type, use_fast=False)
     tokenizer = T5BatchTokenizer(tokenizer, options.batch_size)
     return T5Reranker(model, tokenizer)
 
@@ -91,7 +91,7 @@ def construct_transformer(options:
     model = AutoModel.from_pretrained(options.model,
                                       from_tf=options.from_tf).to(device).eval()
     tokenizer = SimpleBatchTokenizer(AutoTokenizer.from_pretrained(
-        options.tokenizer_name),
+        options.tokenizer_name, use_fast=False),
         options.batch_size)
     provider = CosineSimilarityMatrixProvider()
     return UnsupervisedTransformerReranker(model, tokenizer, provider)
@@ -102,7 +102,7 @@ def construct_seq_class_transformer(options: DocumentRankingEvaluationOptions
     model = AutoModelForSequenceClassification.from_pretrained(options.model, from_tf=options.from_tf)
     device = torch.device(options.device)
     model = model.to(device).eval()
-    tokenizer = AutoTokenizer.from_pretrained(options.tokenizer_name)
+    tokenizer = AutoTokenizer.from_pretrained(options.tokenizer_name, use_fast=False)
     return SequenceClassificationTransformerReranker(model, tokenizer)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ scipy>=1.4
 spacy==2.2.4
 tensorboard>=2.1.0
 tensorflow>=2.2.0rc1
-tokenizers==0.7
+tokenizers==0.9.4
 tqdm==4.45.0
-transformers==2.10.0
+transformers==4.0.0rc1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ tensorboard>=2.1.0
 tensorflow>=2.2.0rc1
 tokenizers==0.9.4
 tqdm==4.45.0
-transformers==4.0.0rc1
+transformers==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tensorflow>=2.2.0rc1
 tokenizers==0.9.4
 tqdm==4.45.0
 transformers==4.0.0
+sentencepiece==0.1.94


### PR DESCRIPTION
1. `sentencepiece` need to be installed saperately in transformers 4.0.0 for slow Tokenizers e.g. T5Tokenizer.
2. set `use_fast=False` for Tokenizers to make sure tokenizers have same behavior as before
3. change "max_length" padding for T5 to "longest" padding which gives same result with taking 1/3 time.

replicated msmarco-subset
https://colab.research.google.com/drive/1xt0a-EvGO7zprCoBUjtBQFdB4WL9nwuT?usp=sharing