### PR TITLE
Replication of monoBERT & monoT5 Baselines for MSMARCO Passage Ranking

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -169,3 +169,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@stephaniewhoo](https://github.com/stephaniewhoo) on 2020-10-25 (commit[`e815051`](https://github.com/castorini/pygaggle/commit/e815051f2cee1af98b370ee030b66c07a8a287f3)) (Tesla V100 on Compute Canada)
 + Results replicated by [@rayyang29](https://github.com/rayyang29) on 2020-11-05 (commit[`19b16d2`](https://github.com/castorini/pygaggle/commit/19b16d28b20bbcead359fc9b4086f33e5c7598f9)) (Tesla T4)
 + Results replicated by [@estella98](https://github.com/estella98) on 2020-11-10 (commit[`5e1e0dd`](https://github.com/castorini/pygaggle/commit/5e1e0dd37c71560e46e8a7f4aa1617b1affd23a7)) (Tesla T4 on Colab) 
++ Results replicated by [@rakeeb123](https://github.com/rakeeb123) on 2020-12-10 (commit[`9a1fe70`](https://github.com/castorini/pygaggle/commit/9a1fe703711011cde69cd78968cb3f00190a3144)) (GeForce 940MX and Tesla V100 on Compute Canada)


### PR DESCRIPTION
Modifying replication log to track that I was successfully able to replicate the monoBERT and monoT5 baseline for a subset of the MSMARCO Passage tasks (available here: https://www.dropbox.com/s/5xa5vjbjle0c8jv/msmarco_ans_small.zip).

I replicated both of these baselines in two environments:
1) Ubuntu 20.04 using a GeForce 940MX, Python 3.8.5, Java 11, CUDA 11.0
2) ComputeCanada supercomputer with Tesla V100, Python 3.8, Java 13, CUDA 10.1

In the second environment, there were no issues obtaining the results.

In the first environment, the following problems were encountered:
1) When running monoBERT baseline, encountered ```ImportError: cannot import name 'AutoModel' from 'transformers'```. See https://github.com/huggingface/transformers/issues/4172 for more details. This was fixed by running ```pip install torch```.
2) CUDA was not installed. Followed CUDA Toolkit installation steps to fix.
3) PyTorch was not detecting libcudart.so.11.1, which was located at ```/usr/local/cuda-11.1/lib64```. I had to append this path to LD_LIBRARY_PATH. 
4) Exception due to Line 149 of pygaggle/rerank/transformer.py during monoBERT baseline replication. Had to remove return_dict=False (this was not committed since the same change was not necessary in the Compute Canada environment).

