### PR TITLE
MS MARCO Passage Retrieval - Subset Replication

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -170,3 +170,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@rayyang29](https://github.com/rayyang29) on 2020-11-05 (commit[`19b16d2`](https://github.com/castorini/pygaggle/commit/19b16d28b20bbcead359fc9b4086f33e5c7598f9)) (Tesla T4)
 + Results replicated by [@estella98](https://github.com/estella98) on 2020-11-10 (commit[`5e1e0dd`](https://github.com/castorini/pygaggle/commit/5e1e0dd37c71560e46e8a7f4aa1617b1affd23a7)) (Tesla T4 on Colab) 
 + Results replicated by [@rakeeb123](https://github.com/rakeeb123) on 2020-12-10 (commit[`9a1fe70`](https://github.com/castorini/pygaggle/commit/9a1fe703711011cde69cd78968cb3f00190a3144)) (GeForce 940MX and Tesla V100 on Compute Canada)
++ Results replicated by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2021-01-01 (commit[`968363e`](https://github.com/castorini/pygaggle/commit/968363ee27bd3ec4d20bdf89eb5cd41e1a6410a5)) (Tesla P100 on Compute Canada)


### PR DESCRIPTION
**Re-Ranking with monoBERT**

I've got the same results
```
precision@1 0.27619
recall@3    0.42698
recall@50   0.81746
recall@1000 0.84762
mrr         0.4109
mrr@10      0.40268
```
**Re-Ranking with monoT5**

I've got approximately the same results
```
precision@1 0.27619
recall@3    0.4746
recall@50   0.80635
recall@1000 0.84762
mrr         0.39734
mrr@10      0.38983
```
**Issues**

The current commands in the doc give the following error (caused by #127):
```
  File "pygaggle/pygaggle/run/evaluate_passage_ranker.py", line 208, in <module>
    main()
  File "pygaggle/pygaggle/run/evaluate_passage_ranker.py", line 178, in main
    options = PassageRankingEvaluationOptions(**vars(args))
  File ".../.../pydantic/main.py", line 338, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for PassageRankingEvaluationOptions
duo_model
  none is not an allowed value (type=type_error.none.not_allowed)
```
I worked around this by specifying the `duo_model` as empty string