### PR TITLE
Replicated PyGaggle: Neural Ranking Baselines on MS MARCO Passage Retrieval - Dev Subset

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -171,3 +171,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@estella98](https://github.com/estella98) on 2020-11-10 (commit[`5e1e0dd`](https://github.com/castorini/pygaggle/commit/5e1e0dd37c71560e46e8a7f4aa1617b1affd23a7)) (Tesla T4 on Colab) 
 + Results replicated by [@rakeeb123](https://github.com/rakeeb123) on 2020-12-10 (commit[`9a1fe70`](https://github.com/castorini/pygaggle/commit/9a1fe703711011cde69cd78968cb3f00190a3144)) (GeForce 940MX and Tesla V100 on Compute Canada)
 + Results replicated by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2021-01-01 (commit[`968363e`](https://github.com/castorini/pygaggle/commit/968363ee27bd3ec4d20bdf89eb5cd41e1a6410a5)) (Tesla P100 on Compute Canada)
++ Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-01-08 (commit[`c7fdc4f`](https://github.com/castorini/pygaggle/commit/c7fdc4f46375a05f02d62fdfd549d43cefad3537)) (Nvidia GeForce GTX 1060)


### PR DESCRIPTION
GPU: Nvidia GeForce GTX 1060
OS: Ubuntu 20.04.1 LTS
JDK: 11.0.9.1
Maven: 3.6.3

Replicated successfully and without any issues:

Sanity Check
![PyGaggle_Passage_Subset_Sanity_Check](https://user-images.githubusercontent.com/28762332/104116579-c02c8c00-52e7-11eb-8d55-fb3eaab0a89a.png)

monoBERT
![PyGaggle_Passage_Subset_monoBERT](https://user-images.githubusercontent.com/28762332/104116580-c28ee600-52e7-11eb-8abf-cfa1c0210e3e.png)

monoT5
![PyGaggle_Passage_Subset_monoT5](https://user-images.githubusercontent.com/28762332/104116582-c458a980-52e7-11eb-9805-19bcc4ea14c1.png)
