### PR TITLE
Fixed Document Title Type Mismatch

### DIFF
--- a/pygaggle/data/segmentation.py
+++ b/pygaggle/data/segmentation.py
@@ -59,7 +59,7 @@ class SegmentProcessor:
             else:
                 for i in range(0, len(sentences), stride):
                     segment_text = ' '.join(sentences[i:i + seg_size])
-                    if not document.title == '':
+                    if document.title and (not document.title == ''):
                         segment_text = document.title + '. ' + segment_text
                     segmented_docs.append(Text(segment_text, dict(docid=document.metadata["docid"])))
                     if i + seg_size >= len(sentences):


### PR DESCRIPTION
When replicating fh of "PyGaggle: Baselines on MS MARCO Document Retrieval," I got the error:
![Screenshot from 2021-01-13 00-44-11](https://user-images.githubusercontent.com/28762332/104491420-365b1800-55a0-11eb-8945-8b717baa4782.png)

It seems that document titles default to None instead of '' (empty string) (see class Text in pygaggle/rerank/base.py), so I added an extra condition in the if statement to prevent type mismatch (pygaggle/data/segmentation.py).

The error from fh of the replication task no longer appears after this change.
However, I got somewhat different results from the replication document results (same as https://github.com/castorini/pygaggle/pull/137#issuecomment-756386914 though):
![Screenshot from 2021-01-13 13-06-36](https://user-images.githubusercontent.com/28762332/104491563-6c989780-55a0-11eb-891c-a52c48684ab7.png)