### PR TITLE
Add DPR Reader

### DIFF
--- a/docs/experiments-dpr-reader.md
+++ b/docs/experiments-dpr-reader.md
@@ -34,36 +34,18 @@ pip install tensorflow_gpu
 We download the queries, top passages from the retriever, and ground truth answers. We download the examples in `data/` using
 ```
 cd data/
-wget https://www.dropbox.com/s/59yksu3lpa7dhdm/retrieval.dpr.bf.json
+wget https://www.dropbox.com/s/5izln5ws7aqn8am/retrieval_dpr_50.json
 ```
 
-As a sanity check, the MD5sum of this file is `2f60d44cfa63fc24f249ab820120e973`.
+As a sanity check, the MD5sum of this file is `d0dd6edc9f7ac77956b5f9998b803fd2`.
 
-If you are experiencing RAM issues, we can split the retrieval file into multiple files in the `retrieval_dpr/` directory by running this Python script
-```
-import json
-import math
-
-with open('retrieval.dpr.bf.json', 'r') as f:
-    data = json.load(f)
-    l = len(data)
-    for i in range(int(math.ceil(l / 1000.))):
-        data2 = {}
-        for j in range(1000):
-            k = f"{1000*i+j}"
-            if k in data:
-                data2[k] = data[k]
-        with open(f'retrieval_dpr/batch_{i}', 'w', encoding='utf-8', newline='\n') as f2:
-            json.dump(data2, f2, indent=4)
-```
-
-Now, let's evaluate the DPR Reader. Run the following command, replacing `<Retrieval File>` with `data/retrieval.dpr.bf.json` or `data/retrieval_dpr/`, depending on the retrieval file/directory location.
+Now, let's evaluate the DPR Reader.
 
 ```
 cd ../
 python -um pygaggle.run.evaluate_passage_reader --task wikipedia \
                                                 --method dpr \ 
-                                                --retrieval-file <Retrieval File> \
+                                                --retrieval-file data/retrieval_dpr_50.json \
                                                 --output-file my_dpr_prediction.json \
                                                 --use-top-k-passages 10
 ```

--- a/docs/experiments-dpr-reader.md
+++ b/docs/experiments-dpr-reader.md
@@ -1,0 +1,82 @@
+# PyGaggle: Dense Passage Retrieval (DPR) Baselines
+
+This page contains instructions for running the Dense Passage Retrieval tools.
+
+First, clone the PyGaggle repository recursively.
+
+```
+git clone --recursive https://github.com/castorini/pygaggle.git
+cd pygaggle/
+```
+Then load Java module:
+```
+module load java
+```
+Then install Pytorch.
+```
+pip install torch
+```
+Then install PyGaggle by the following command.
+```
+pip install -r requirements.txt
+```
+Note: On Compute Canada, you may have to install tensorflow separately by the following command.
+```
+pip install tensorflow_gpu 
+```
+
+## Models
+
++ Dense Passage Retrieval for Open-Domain Question Answering [(Karpukhin et al., 2020)](https://arxiv.org/pdf/2004.04906.pdf)
+
+## Data Prep
+
+We download the queries, top passages from the retriever, and ground truth answers. We download the examples in `data/` using
+```
+cd data/
+wget https://www.dropbox.com/s/59yksu3lpa7dhdm/retrieval.dpr.bf.json
+```
+
+As a sanity check, the MD5sum of this file is `2f60d44cfa63fc24f249ab820120e973`.
+
+If you are experiencing RAM issues, we can split the retrieval file into multiple files in the `retrieval_dpr/` directory by running this Python script
+```
+import json
+import math
+
+with open('retrieval.dpr.bf.json', 'r') as f:
+    data = json.load(f)
+    l = len(data)
+    for i in range(int(math.ceil(l / 1000.))):
+        data2 = {}
+        for j in range(1000):
+            k = f"{1000*i+j}"
+            if k in data:
+                data2[k] = data[k]
+        with open(f'retrieval_dpr/batch_{i}', 'w', encoding='utf-8', newline='\n') as f2:
+            json.dump(data2, f2, indent=4)
+```
+
+Now, let's evaluate the DPR Reader. Run the following command, replacing `<Retrieval File>` with `data/retrieval.dpr.bf.json` or `data/retrieval_dpr/`, depending on the retrieval file/directory location.
+
+```
+cd ../
+python -um pygaggle.run.evaluate_passage_reader --task wikipedia \
+                                                --method dpr \ 
+                                                --retrieval-file <Retrieval File> \
+                                                --output-file my_dpr_prediction.json \
+                                                --use-top-k-passages 10
+```
+
+The final Exact Match (EM) score after 8757 queries should be `39.07730958090671`.
+
+It takes about 1-2 hours to read and answer all of the queries a V100. 
+The type of GPU will directly influence your inference time. 
+
+If you were able to replicate these results, please submit a PR adding to the replication log!
+Please mention in your PR if you find any difference!
+
+
+## Replication Log
+
++ Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-02-05 (commit[`de20456`](https://github.com/castorini/pygaggle/commit/de2045635106abf104cd7adaf07525fd4f173a3b)) (Tesla V100 on Compute Canada)

--- a/docs/experiments-dpr-reader.md
+++ b/docs/experiments-dpr-reader.md
@@ -52,8 +52,8 @@ python -um pygaggle.run.evaluate_passage_reader --task wikipedia \
 
 The final Exact Match (EM) score after 8757 queries should be `39.07730958090671`.
 
-It takes about 1-2 hours to read and answer all of the queries a V100. 
-The type of GPU will directly influence your inference time. 
+It should take about 1-2 hours to read and answer all of the queries on a GPU.
+The type of GPU will directly influence your inference time.
 
 If you were able to replicate these results, please submit a PR adding to the replication log!
 Please mention in your PR if you find any difference!

--- a/pygaggle/data/retrieval.py
+++ b/pygaggle/data/retrieval.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import List
+
+from pygaggle.rerank.base import Query, Text
+
+
+@dataclass
+class RetrievalExample:
+    query: Query
+    texts: List[Text]
+    groundTruthAnswers: List[List[str]]

--- a/pygaggle/model/evaluate.py
+++ b/pygaggle/model/evaluate.py
@@ -245,6 +245,14 @@ class DuoRerankerEvaluator:
         return metrics
 
 class ReaderEvaluator:
+    """Class for evaluating a reader.
+    Takes in a list of examples (query, texts, ground truth answers),
+    predicts a list of answers using the Reader passed in, and
+    collects the exact match accuracies between the best answer and
+    the ground truth answers given in the example.
+    Exact match scoring used is identical to the DPR repository.
+    """
+
     def __init__(
         self,
         reader: Reader,
@@ -274,10 +282,7 @@ class ReaderEvaluator:
         return ems
 
     @staticmethod
-    def exact_match_score(
-        prediction: str,
-        ground_truth: str,
-    ):
+    def exact_match_score(prediction, ground_truth):
         return ReaderEvaluator._normalize_answer(prediction) == ReaderEvaluator._normalize_answer(ground_truth)
 
     @staticmethod

--- a/pygaggle/model/evaluate.py
+++ b/pygaggle/model/evaluate.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import List, Optional
+from typing import List, Optional, Dict
 import abc
 
 from sklearn.metrics import recall_score
@@ -254,6 +254,7 @@ class ReaderEvaluator:
     def evaluate(
         self,
         examples: List[RetrievalExample],
+        dpr_predictions: Optional[List[Dict[str, str]]] = None,
     ):
         ems = []
         for example in tqdm(examples):
@@ -263,6 +264,12 @@ class ReaderEvaluator:
             groundTruthAnswers = example.groundTruthAnswers
             em_hit = max([ReaderEvaluator.exact_match_score(bestAnswer, ga) for ga in groundTruthAnswers])
             ems.append(em_hit)
+
+            if dpr_predictions is not None:
+                dpr_predictions.append({
+                    'question': example.query.text,
+                    'prediction': bestAnswer,
+                })
 
         return ems
 

--- a/pygaggle/reader/base.py
+++ b/pygaggle/reader/base.py
@@ -1,0 +1,69 @@
+from typing import List, Optional, Mapping, Any
+import abc
+
+from ..reranker.base import Query, Text
+
+class Answer:
+    """
+    Class representing an answer.
+    A answer contains the answer text itself and potentially other metadata.
+    Parameters
+    ----------
+    text : str
+        The answer text.
+    metadata : Mapping[str, Any]
+        Additional metadata and other annotations.
+    score : Optional[float]
+        The score of the answer.
+    ctx_score : Optional[float]
+        The context score of the answer.
+    total_score : Optional[float]
+        The aggregated score of answer score and ctx_score
+    """
+    def __init__(
+        self,
+        text: str,
+        language: str = "en",
+        metadata: Mapping[str, Any] = None,
+        score: Optional[float] = 0,
+        ctx_score: Optional[float] = 0,
+        total_score: Optional[float] = 0,
+    ):
+        self.text = text
+        self.language = language
+        if metadata is None:
+            metadata = dict()
+        self.metadata = metadata
+        self.score = score
+        self.ctx_score = ctx_score
+        self.total_score = total_score
+
+    def aggregate_score(self, weight):
+        self.total_score = weight*self.score + (1-weight)*self.ctx_score
+
+
+class Reader:
+    """
+    Class representing a Reader.
+    A Reader takes a Query and a list of Text and returns a list of Answer.
+    """
+    @abc.abstractmethod
+    def predict(
+        self,
+        query: Query,
+        texts: List[Text],
+    ) -> List[Answer]:
+        """
+            Find answers from a list of texts with respect to a query.
+            Parameters
+            ----------
+            query : Query
+                The query.
+            texts : List[Text]
+                The list of texts.
+            Returns
+            -------
+            List[Answer]
+                Predicted list of answers.
+        """
+        pass

--- a/pygaggle/reader/base.py
+++ b/pygaggle/reader/base.py
@@ -1,7 +1,8 @@
 from typing import List, Optional, Mapping, Any
 import abc
 
-from ..reranker.base import Query, Text
+from pygaggle.rerank.base import Query, Text
+
 
 class Answer:
     """

--- a/pygaggle/reader/dpr_reader.py
+++ b/pygaggle/reader/dpr_reader.py
@@ -1,0 +1,61 @@
+from typing import List
+
+from transformers import DPRReader, DPRReaderTokenizer
+
+from .base import Reader, Answer
+from ..reranker.base import Query, Text
+
+class DPRReader(Reader):
+    def __init__(
+        self,
+        model_name: str,
+        tokenizer_name: str = None,
+        num_spans: int = 16,
+        max_answer_length: int = 64,
+        num_spans_per_passage: int = 4,
+    ):
+        if tokenizer_name is None:
+            tokenizer_name = model_name
+
+        self.tokenizer = DPRReaderTokenizer.from_pretrained(tokenizer_name)
+        self.model = DPRReader.from_pretrained(model_name)
+
+        self.num_spans = num_spans
+        self.max_answer_length = max_answer_length
+        self.num_spans_per_passage = num_spans_per_passage
+
+    def predict(
+        self,
+        query: Query,
+        texts: List[Text],
+    ) -> List[Answer]:
+        # Each text should have format "title\ncontent"
+        titles, contents = tuple(map(list, zip(*map(lambda t: t.text.split('\n', 1), texts))))
+
+        encoded_inputs = self.tokenizer(
+            questions=[query.text],
+            titles=titles,
+            texts=contents,
+            return_tensors='pt',
+        )
+        outputs = self.model(**encoded_inputs)
+
+        predicted_spans = tokenizer.decode_best_spans(
+            encoded_inputs,
+            outputs,
+            self.num_spans,
+            self.max_answer_length,
+            self.num_spans_per_passage,
+        )
+
+        answers = []
+        for idx, span in enumerate(predicted_spans):
+            answers.append(
+                Answer(
+                    text=span.text,
+                    score=span.span_score,
+                    ctx_score=span.relevance_score,
+                )
+            )
+
+        return answers

--- a/pygaggle/reader/dpr_reader.py
+++ b/pygaggle/reader/dpr_reader.py
@@ -11,9 +11,9 @@ class DensePassageRetrieverReader(Reader):
         self,
         model: DPRReader = None,
         tokenizer: DPRReaderTokenizer = None,
-        num_spans: int = 16,
-        max_answer_length: int = 64,
-        num_spans_per_passage: int = 4,
+        num_spans: int = 1,
+        max_answer_length: int = 10,
+        num_spans_per_passage: int = 10,
     ):
         self.model = model or self.get_model()
         self.tokenizer = tokenizer or self.get_tokenizer()

--- a/pygaggle/reader/dpr_reader.py
+++ b/pygaggle/reader/dpr_reader.py
@@ -8,6 +8,19 @@ from pygaggle.rerank.base import Query, Text
 
 
 class DensePassageRetrieverReader(Reader):
+    """Class containing the DPR Reader
+    Takes in a query and a list of the top passages selected by the retrieval model,
+    and predicts a list of the best answer spans from the most relevant passages, reranked.
+
+    Parameters
+    ----------
+    model : DPR Reader model for predicting start, end, and relevance logits
+    tokenizer : DPR Reader tokenizer for encoding input query and texts
+    num_spans : Number of answer spans to return
+    max_answer_length : Maximum length that an answer span can be
+    num_spans_per_passage : Maximum number of answer spans to return per passage
+    """
+
     def __init__(
         self,
         model: DPRReader = None,

--- a/pygaggle/reader/dpr_reader.py
+++ b/pygaggle/reader/dpr_reader.py
@@ -3,44 +3,51 @@ from typing import List
 from transformers import DPRReader, DPRReaderTokenizer
 
 from .base import Reader, Answer
-from ..reranker.base import Query, Text
+from pygaggle.rerank.base import Query, Text
 
-class DPRReader(Reader):
+
+class DensePassageRetrieverReader(Reader):
     def __init__(
         self,
-        model_name: str,
-        tokenizer_name: str = None,
+        model: DPRReader = None,
+        tokenizer: DPRReaderTokenizer = None,
         num_spans: int = 16,
         max_answer_length: int = 64,
         num_spans_per_passage: int = 4,
     ):
-        if tokenizer_name is None:
-            tokenizer_name = model_name
-
-        self.tokenizer = DPRReaderTokenizer.from_pretrained(tokenizer_name)
-        self.model = DPRReader.from_pretrained(model_name)
+        self.model = model or self.get_model()
+        self.tokenizer = tokenizer or self.get_tokenizer()
 
         self.num_spans = num_spans
         self.max_answer_length = max_answer_length
         self.num_spans_per_passage = num_spans_per_passage
+
+    @staticmethod
+    def get_model(
+        pretrained_model_name_or_path: str = 'facebook/dpr-reader-single-nq-base',
+    ) -> DPRReader:
+        return DPRReader.from_pretrained(pretrained_model_name_or_path)
+
+    @staticmethod
+    def get_tokenizer(
+        pretrained_tokenizer_name_or_path: str = 'facebook/dpr-reader-single-nq-base',
+    ) -> DPRReaderTokenizer:
+        return DPRReaderTokenizer.from_pretrained(pretrained_tokenizer_name_or_path)
 
     def predict(
         self,
         query: Query,
         texts: List[Text],
     ) -> List[Answer]:
-        # Each text should have format "title\ncontent"
-        titles, contents = tuple(map(list, zip(*map(lambda t: t.text.split('\n', 1), texts))))
-
         encoded_inputs = self.tokenizer(
             questions=[query.text],
-            titles=titles,
-            texts=contents,
+            titles=list(map(lambda t: t.title, texts)),
+            texts=list(map(lambda t: t.text, texts)),
             return_tensors='pt',
         )
         outputs = self.model(**encoded_inputs)
 
-        predicted_spans = tokenizer.decode_best_spans(
+        predicted_spans = self.tokenizer.decode_best_spans(
             encoded_inputs,
             outputs,
             self.num_spans,

--- a/pygaggle/run/evaluate_passage_reader.py
+++ b/pygaggle/run/evaluate_passage_reader.py
@@ -43,10 +43,10 @@ def construct_dpr(options: PassageReadingEvaluationOptions) -> Reader:
 
 def display(ems):
     if len(ems) == 0:
-        em = -0.01
+        em = -1.
     else:
-        em = np.mean(np.array(ems))
-    logging.info(f'Exact Match Accuracy: {em * 100}')
+        em = np.mean(np.array(ems)) * 100.
+    logging.info(f'Exact Match Accuracy: {em}')
 
 def main():
     apb = ArgumentParserBuilder()

--- a/pygaggle/run/evaluate_passage_reader.py
+++ b/pygaggle/run/evaluate_passage_reader.py
@@ -42,7 +42,10 @@ def construct_dpr(options: PassageReadingEvaluationOptions) -> Reader:
                                        options.num_spans_per_passage)
 
 def display(ems):
-    em = np.mean(np.array(ems))
+    if len(ems) == 0:
+        em = -0.01
+    else:
+        em = np.mean(np.array(ems))
     logging.info(f'Exact Match Accuracy: {em * 100}')
 
 def main():
@@ -120,6 +123,7 @@ def main():
 
     for filename in files:
         logging.info(f'Read {nQueries} queries.')
+        display(ems)
         with open(filename) as f:
             data = json.load(f)
 
@@ -135,7 +139,6 @@ def main():
             )
 
         ems.extend(evaluator.evaluate(examples, dpr_predictions))
-        display(ems)
 
     logging.info(f'Reader completed.\nRead {nQueries} queries.')
     display(ems)

--- a/pygaggle/run/evaluate_passage_reader.py
+++ b/pygaggle/run/evaluate_passage_reader.py
@@ -48,17 +48,49 @@ def display(ems):
 def main():
     apb = ArgumentParserBuilder()
     apb.add_opts(
-        opt('--task', type=str, default='wikipedia'),
-        opt('--method', type=str, required=True, choices=METHOD_CHOICES),
-        opt('--retrieval-file', type=Path, required=True),
-        opt('--model-name', type=str, default='facebook/dpr-reader-single-nq-base'),
-        opt('--tokenizer-name', type=str, default='facebook/dpr-reader-single-nq-base'),
-        opt('--use-top-k-passages', type=int, default=50),
-        opt('--num-spans', type=int, default=1),
-        opt('--max-answer-length', type=int, default=10),
-        opt('--num-spans-per-passage', type=int, default=10),
-        opt('--output-file', type=Path, default=None),
-        opt('--device', type=str, default='cuda:0'),
+        opt('--task',
+            type=str,
+            default='wikipedia'),
+        opt('--method',
+            type=str,
+            required=True,
+            choices=METHOD_CHOICES),
+        opt('--retrieval-file',
+            type=Path,
+            required=True,
+            help='JSON file containing top passages selected by the retrieval model'),
+        opt('--model-name',
+            type=str,
+            default='facebook/dpr-reader-single-nq-base',
+            help='Pretrained model for reader'),
+        opt('--tokenizer-name',
+            type=str,
+            default='facebook/dpr-reader-single-nq-base',
+            help='Pretrained model for tokenizer'),
+        opt('--use-top-k-passages',
+            type=int,
+            default=50,
+            help='The top k passages by the retriever will be used by the reader'),
+        opt('--num-spans',
+            type=int,
+            default=1,
+            help='Number of answer spans to return'),
+        opt('--max-answer-length',
+            type=int,
+            default=10,
+            help='Maximum length that an answer span can be'),
+        opt('--num-spans-per-passage',
+            type=int,
+            default=10,
+            help='Maximum number of answer spans to return per passage'),
+        opt('--output-file',
+            type=Path,
+            default=None,
+            help='File to output predictions for each example; if no output file specified, this output will be discarded'),
+        opt('--device',
+            type=str,
+            default='cuda:0',
+            help='Device for model computations'),
     )
     args = apb.parser.parse_args()
     options = PassageReadingEvaluationOptions(**vars(args))
@@ -86,8 +118,8 @@ def main():
     else:
         dpr_predictions = None
 
-    for idx, filename in enumerate(files):
-        logging.info(f'Read {1000*idx} queries.')
+    for filename in files:
+        logging.info(f'Read {nQueries} queries.')
         with open(filename) as f:
             data = json.load(f)
 

--- a/pygaggle/run/evaluate_passage_reader.py
+++ b/pygaggle/run/evaluate_passage_reader.py
@@ -1,0 +1,106 @@
+from typing import Optional
+from pathlib import Path
+import logging
+import json
+import os
+import numpy as np
+
+from pydantic import BaseModel
+from transformers import (DPRReader,
+                          DPRReaderTokenizer)
+
+from .args import ArgumentParserBuilder, opt
+from pygaggle.reader.base import Reader
+from pygaggle.reader.dpr_reader import DensePassageRetrieverReader
+from pygaggle.data.retrieval import RetrievalExample
+from pygaggle.rerank.base import Query, Text
+from pygaggle.model.evaluate import ReaderEvaluator
+
+METHOD_CHOICES = ('dpr')
+
+
+class PassageReadingEvaluationOptions(BaseModel):
+    task: str
+    method: str
+    retrieval_file: Path
+    model_name: Optional[str]
+    tokenizer_name: Optional[str]
+    use_top_k_passages: int
+    num_spans: int
+    max_answer_length: int
+    num_spans_per_passage: int
+
+def construct_dpr(options: PassageReadingEvaluationOptions) -> Reader:
+    model = DensePassageRetrieverReader.get_model(options.model_name)
+    tokenizer = DensePassageRetrieverReader.get_tokenizer(options.tokenizer_name)
+
+    return DensePassageRetrieverReader(model,
+                                       tokenizer,
+                                       options.num_spans,
+                                       options.max_answer_length,
+                                       options.num_spans_per_passage)
+
+def display(ems):
+    em = np.mean(np.array(ems))
+    logging.info(f'Exact Match Accuracy: {em * 100}')
+
+def main():
+    apb = ArgumentParserBuilder()
+    apb.add_opts(
+        opt('--task', type=str, default='wikipedia'),
+        opt('--method', type=str, required=True, choices=METHOD_CHOICES),
+        opt('--retrieval-file', type=Path, required=True),
+        opt('--model-name', type=str, default='facebook/dpr-reader-single-nq-base'),
+        opt('--tokenizer-name', type=str, default='facebook/dpr-reader-single-nq-base'),
+        opt('--use-top-k-passages', type=int, default=50),
+        opt('--num-spans', type=int, default=1),
+        opt('--max-answer-length', type=int, default=10),
+        opt('--num-spans-per-passage', type=int, default=10),
+    )
+    args = apb.parser.parse_args()
+    options = PassageReadingEvaluationOptions(**vars(args))
+
+    logging.info("Loading Reader Model and Tokenizer.")
+    construct_map = dict(
+        dpr=construct_dpr,
+    )
+    reader = construct_map[options.method](options)
+
+    evaluator = ReaderEvaluator(reader)
+
+    retrievalFile = options.retrieval_file
+    if os.path.isfile(retrievalFile):
+        files = [retrievalFile]
+    else:
+        files = os.listdir(retrievalFile)
+        files.sort()
+        files = map(lambda filename: os.path.join(retrievalFile, filename), files)
+
+    ems = []
+    nQueries = 0
+
+    for idx, filename in enumerate(files):
+        logging.info(f'Read {1000*idx} queries.')
+        with open(filename) as f:
+            data = json.load(f)
+
+        nQueries += len(data)
+        examples = []
+        for _, item in data.items():
+            examples.append(
+                RetrievalExample(
+                    query=Query(text=item["question"]),
+                    texts=list(map(lambda context: Text(text=context["text"].split('\n', 1)[1], title=context["text"].split('\n', 1)[0][1:-1]), item["contexts"]))[:options.use_top_k_passages],
+                    groundTruthAnswers=item["answers"],
+                )
+            )
+
+        ems.extend(evaluator.evaluate(examples))
+        display(ems)
+
+    logging.info(f'Reader completed.\nRead {nQueries} queries.')
+    display(ems)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Draft for adding a Reader module and DPRReader in PyGaggle (https://github.com/castorini/pygaggle/issues/149).

TODO: Test DPRReader by replicating the results in DPR paper.

**Description of Code**

pygaggle/model/evaluate.py: class ReaderEvaluator - Takes in the examples (query, texts, ground truth answers), predicts answers using the DPRReader, and compares the top answer with the ground truth answers using exact match. Like https://github.com/facebookresearch/DPR/blob/f403c3b3e179e53c0fe68a0718d5dc25371fe5df/train_reader.py#L186.

pygaggle/reader/dpr_reader.py: class DensePassageRetrieverReader - Predicts answers from a query and texts, like in https://huggingface.co/transformers/v3.2.0/_modules/transformers/tokenization_dpr.html.

pygaggle/run/evaluate_passage_reader.py: The main content starts on Line 82, which will group the examples into 1000-sized batches (since 8757 queries at once gave me RAM issues) and evaluate them. The exact match scores are extended into one list, and averaged to get the overall EM score.

Colab link: https://colab.research.google.com/drive/1d3BYhpo71YUKcCOLyPLT4Ulvc71yxF78?usp=sharing