### PR TITLE
Avoid ignored batch size argument - for duoT5

### DIFF
--- a/docs/experiments-duot5-tpu.md
+++ b/docs/experiments-duot5-tpu.md
@@ -183,7 +183,7 @@ for ITER in {000..034}; do
     --gin_param="Bitransformer.decode.max_decode_length = 2" \
     --gin_param="input_filename = '${GS_FOLDER}/query_docs_triples.dev.small.txt${ITER}'" \
     --gin_param="output_filename = '${GS_FOLDER}/query_docs_triple_scores.dev.small.txt${ITER}'" \
-    --gin_param="tokens_per_batch = 65536" \
+    --gin_param="utils.run.batch_size=('tokens_per_batch', 65536)" \
     --gin_param="Bitransformer.decode.beam_size = 1" \
     --gin_param="Bitransformer.decode.temperature = 0.0" \
     --gin_param="Unitransformer.sample_autoregressive.sampling_keep_top_k = -1" \


### PR DESCRIPTION
The newer versions of the T5 library simply ignore --gin_param="tokens_per_batch = 65536" \:
google-research/text-to-text-transfer-transformer#21