### PR TITLE
Add Multi Topk EM

### DIFF
--- a/pygaggle/model/evaluate.py
+++ b/pygaggle/model/evaluate.py
@@ -263,23 +263,28 @@ class ReaderEvaluator:
     def evaluate(
         self,
         examples: List[RetrievalExample],
+        topk_em: List[int] = [50],
         dpr_predictions: Optional[Dict[int, List[Dict[str, str]]]] = None,
     ):
-        ems = { k : [] for k in self.reader.topk_em }
+        ems = { k : [] for k in topk_em }
         for example in tqdm(examples):
-            answers = self.reader.predict(example.query, example.texts)
+            answers = self.reader.predict(example.query, example.texts, topk_em)
             ground_truth_answers = example.ground_truth_answers
 
-            for k in self.reader.topk_em:
+            topk_prediction = {}
+
+            for k in topk_em:
                 best_answer = answers[k][0].text
                 em_hit = max([ReaderEvaluator.exact_match_score(best_answer, ga) for ga in ground_truth_answers])
                 ems[k].append(em_hit)
 
-                if dpr_predictions is not None:
-                    dpr_predictions[k].append({
-                        'question': example.query.text,
-                        'prediction': best_answer,
-                    })
+                topk_prediction[f'top{k}'] = best_answer
+
+            if dpr_predictions is not None:
+                dpr_predictions.append({
+                    'question': example.query.text,
+                    'prediction': topk_prediction,
+                })
 
         return ems
 

--- a/pygaggle/reader/dpr_reader.py
+++ b/pygaggle/reader/dpr_reader.py
@@ -74,6 +74,7 @@ class DensePassageRetrieverReader(Reader):
                     return_tensors='pt',
                     padding=True,
                     truncation=True,
+                    max_length=350,
                 )
                 input_ids = encoded_inputs['input_ids'].to(self.device)
                 attention_mask = encoded_inputs['attention_mask'].to(self.device)


### PR DESCRIPTION
Example usage: `python -um pygaggle.run.evaluate_passage_reader --task wikipedia --method dpr --retrieval-file data/run.dpr.nq.single.bf.top100.json --output-dir dpr_predictions --topk-retrieval 10 20 50 --topk-em 10 20 50`

![Screenshot from 2021-02-12 18-37-40](https://user-images.githubusercontent.com/28762332/107833491-71986480-6d61-11eb-824f-7db29033da14.png)

Top 10 EM: 40.581717451523545
Top 20 EM: 40.83102493074792
Top 50 EM: 41.32963988919667

https://colab.research.google.com/drive/18C0HXbvrLBE95kIM37_B6lXdxMLifBLZ#scrollTo=_DBTDM3uv9Hg

Example of Outputted Prediction JSON:
[actual_dpr_predictions.zip](https://github.com/castorini/pygaggle/files/5974728/actual_dpr_predictions.zip)
