### PR TITLE
finished reproduction

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -173,3 +173,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2021-01-01 (commit[`968363e`](https://github.com/castorini/pygaggle/commit/968363ee27bd3ec4d20bdf89eb5cd41e1a6410a5)) (Tesla P100 on Compute Canada)
 + Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-01-08 (commit[`c7fdc4f`](https://github.com/castorini/pygaggle/commit/c7fdc4f46375a05f02d62fdfd549d43cefad3537)) (Nvidia GeForce GTX 1060)
 + Results replicated by [@wongalvis14](https://github.com/wongalvis14) on 2021-02-22 (commit[`7c0ebbe`](https://github.com/castorini/pygaggle/commit/7c0ebbeb20dc867ee68d21c6ac7da84073bdb6f6)) (GeForce RTX 2080 Ti on Hydra)
++ Results replicated by [@ArthurChen189](https://github.com/ArthurChen189) on 2021-04-15 (commit[`04fae0b`](https://github.com/castorini/pygaggle/commit/04fae0b1868eb29d2ea7b73e38e4c1bc72155f2b)) (Tesla P100 on Colab)


### PR DESCRIPTION
**Platform:** Colab
**Issues:** Running Torch version 1.8.1, which Colab uses as default raises:
`colab cannot import name 'save_state_warning' from 'torch.optim.lr_scheduler' `

I downgraded PyTorch to 1.5.0 and it worked. 
Details and reproduction results can be found in [the notebook](https://colab.research.google.com/drive/1uYexUCKwGZTS5BQB_FmSgxNrVLnGKc9s?usp=sharing)