### PR TITLE
Add specific version of Torch to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ tokenizers==0.9.4
 tqdm==4.45.0
 transformers==4.0.0
 sentencepiece==0.1.94
+torch==1.7.0
+torchvision==0.8.1


### PR DESCRIPTION
- Add Torch to requirements and specify which version to use.
Versions newer than 1.7.0 do not work because of this change in PyTorch: https://github.com/pytorch/pytorch/pull/46813