### PR TITLE
Add rescore

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for i in range(0, 10):
     print(f'{i+1:2} {texts[i].metadata["docid"]:15} {texts[i].score:.5f} {texts[i].text}')
 
 # Finally, rerank:
-reranked = reranker.rerank(query, texts)
+reranked = reranker.rescore(query, texts)
 
 # Print out reranked results:
 for i in range(0, 10):

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for i in range(0, 10):
     print(f'{i+1:2} {texts[i].metadata["docid"]:15} {texts[i].score:.5f} {texts[i].text}')
 
 # Finally, rerank:
-reranked = reranker.rescore(query, texts)
+reranked = reranker.rerank(query, texts)
 
 # Print out reranked results:
 for i in range(0, 10):

--- a/pygaggle/rerank/base.py
+++ b/pygaggle/rerank/base.py
@@ -1,4 +1,5 @@
 from typing import List, Union, Optional, Mapping, Any
+from copy import deepcopy
 import abc
 
 from pyserini.search import JSimpleSearcherResult
@@ -21,6 +22,7 @@ class Query:
     id : Optional[str]
         The query id.
     """
+
     def __init__(self, text: str, id: Optional[str] = None):
         self.text = text
         self.id = id
@@ -63,8 +65,14 @@ class Reranker:
     A reranker takes a list texts and returns a list of texts non-destructively
     (i.e., does not alter the original input list of texts).
     """
+
+    def rerank(self, texts: List[Text]) -> List[Text]:
+        """Sorts a list of texts
+        """
+        return deepcopy(texts.sort(lambda x: x.score))
+
     @abc.abstractmethod
-    def rerank(self, query: Query, texts: List[Text]) -> List[Text]:
+    def rescore(self, query: Query, texts: List[Text]) -> List[Text]:
         """Reranks a list of texts with respect to a query.
 
          Parameters

--- a/pygaggle/rerank/base.py
+++ b/pygaggle/rerank/base.py
@@ -69,7 +69,7 @@ class Reranker:
     def rerank(self, query: Query, texts: List[Text]) -> List[Text]:
         """Sorts a list of texts
         """
-        return sorted(self.rescore(query, texts), key=lambda x: x.score)
+        return sorted(self.rescore(query, texts), key=lambda x: x.score, reverse=True)
 
     @abc.abstractmethod
     def rescore(self, query: Query, texts: List[Text]) -> List[Text]:

--- a/pygaggle/rerank/base.py
+++ b/pygaggle/rerank/base.py
@@ -66,10 +66,10 @@ class Reranker:
     (i.e., does not alter the original input list of texts).
     """
 
-    def rerank(self, texts: List[Text]) -> List[Text]:
+    def rerank(self, query: Query, texts: List[Text]) -> List[Text]:
         """Sorts a list of texts
         """
-        return deepcopy(texts.sort(lambda x: x.score))
+        return sorted(self.rescore(query, texts), key=lambda x: x.score)
 
     @abc.abstractmethod
     def rescore(self, query: Query, texts: List[Text]) -> List[Text]:

--- a/pygaggle/rerank/bm25.py
+++ b/pygaggle/rerank/bm25.py
@@ -26,7 +26,7 @@ class Bm25Reranker(Reranker):
             self.use_corpus_estimator = True
             self.index_utils = IndexReader(index_path)
 
-    def rerank(self, query: Query, texts: List[Text]) -> List[Text]:
+    def rescore(self, query: Query, texts: List[Text]) -> List[Text]:
         query_words = self.analyzer.analyze(query.text)
         sentences = list(map(self.analyzer.analyze, (t.text for t in texts)))
 
@@ -45,7 +45,7 @@ class Bm25Reranker(Reranker):
             if self.use_corpus_estimator:
                 idfs = {w:
                         self.index_utils.compute_bm25_term_weight(
-                                text.metadata['docid'], w) for w in tf}
+                            text.metadata['docid'], w) for w in tf}
             score = sum(idfs[w] * tf[w] * (self.k1 + 1) /
                         (tf[w] + self.k1 * (1 - self.b + self.b *
                                             (d_len / mean_len))) for w in tf)

--- a/pygaggle/rerank/identity.py
+++ b/pygaggle/rerank/identity.py
@@ -7,5 +7,5 @@ __all__ = ['IdentityReranker']
 
 
 class IdentityReranker(Reranker):
-    def rerank(self, query: Query, texts: List[Text]) -> List[Text]:
+    def rescore(self, query: Query, texts: List[Text]) -> List[Text]:
         return texts

--- a/pygaggle/rerank/random.py
+++ b/pygaggle/rerank/random.py
@@ -12,7 +12,7 @@ class RandomReranker(Reranker):
     def __init__(self, seed: int = 0):
         self.rand = random.Random(seed)
 
-    def rerank(self, query: Query, texts: List[Text]) -> List[Text]:
+    def rescore(self, query: Query, texts: List[Text]) -> List[Text]:
         texts = deepcopy(texts)
         for text in texts:
             text.score = self.rand.random()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -57,7 +57,7 @@ class TestSearch(unittest.TestCase):
         identity_reranker = IdentityReranker()
         self.assertTrue(isinstance(identity_reranker, Reranker))
 
-        output = identity_reranker.rerank(query, texts)
+        output = identity_reranker.rescore(query, texts)
 
         # Check that reranked output is indeed the same as the input
         for i in range(0, len(hits)):


### PR DESCRIPTION
This PR renames the existing `rerank` function to `rescore`. It also adds a separate `rerank` function that calls `rescore` and sorts the list of texts that `rescore` returns. It maintains the assumption of the ReRanker class (that it doesn't alter the original input list of text).

--------

This PR is a workaround for the replication issue in https://github.com/castorini/pygaggle/pull/184