### PR TITLE
Add MiniLM cross-encoder reranker

### DIFF
--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -28,7 +28,7 @@ __all__ = ['MonoT5',
            'UnsupervisedTransformerReranker',
            'MonoBERT',
            'QuestionAnsweringTransformerReranker',
-           'CrossEncoderReranker']
+           'SentenceTransformersReranker']
 
 
 class MonoT5(Reranker):
@@ -251,14 +251,14 @@ class QuestionAnsweringTransformerReranker(Reranker):
         return texts
 
 
-class CrossEncoderReranker(Reranker):
+class SentenceTransformersReranker(Reranker):
     def __init__(self,
                  pretrained_model_name_or_path='cross-encoder/ms-marco-MiniLM-L-2-v2',
                  max_length=512,
                  device=None,
-                 use_amp=None):
+                 use_amp=False):
         device = device or ('cuda' if torch.cuda.is_available() else 'cpu')
-        self.use_amp = use_amp or (device == 'cuda')
+        self.use_amp = use_amp
         self.model = CrossEncoder(
             pretrained_model_name_or_path, max_length=max_length, device=device
         )

--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -9,6 +9,7 @@ from transformers import (AutoTokenizer,
                           PreTrainedTokenizer,
                           T5ForConditionalGeneration)
 import torch
+from sentence_transformers import CrossEncoder
 from .base import Reranker, Query, Text
 from .similarity import SimilarityMatrixProvider
 from pygaggle.model import (BatchTokenizer,
@@ -26,7 +27,8 @@ __all__ = ['MonoT5',
            'DuoT5',
            'UnsupervisedTransformerReranker',
            'MonoBERT',
-           'QuestionAnsweringTransformerReranker']
+           'QuestionAnsweringTransformerReranker',
+           'CrossEncoderReranker']
 
 
 class MonoT5(Reranker):
@@ -245,5 +247,31 @@ class QuestionAnsweringTransformerReranker(Reranker):
             smax_val, smax_idx = start_scores.max(0)
             emax_val, emax_idx = end_scores.max(0)
             text.score = max(smax_val.item(), emax_val.item())
+
+        return texts
+
+
+class CrossEncoderReranker(Reranker):
+    def __init__(self,
+                 pretrained_model_name_or_path='cross-encoder/ms-marco-MiniLM-L-2-v2',
+                 max_length=512,
+                 device=None,
+                 use_amp=None):
+        device = device or ('cuda' if torch.cuda.is_available() else 'cpu')
+        self.use_amp = use_amp or (device == 'cuda')
+        self.model = CrossEncoder(
+            pretrained_model_name_or_path, max_length=max_length, device=device
+        )
+
+    def rescore(self, query: Query, texts: List[Text]) -> List[Text]:
+        texts = deepcopy(texts)
+        with torch.cuda.amp.autocast(enabled=self.use_amp):
+            scores = self.model.predict(
+                [(query.text, text.text) for text in texts],
+                show_progress_bar=False,
+            )
+
+        for (text, score) in zip(texts, scores):
+            text.score = score.item()
 
         return texts

--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -275,3 +275,4 @@ class SentenceTransformersReranker(Reranker):
             text.score = score.item()
 
         return texts
+        

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ tokenizers==0.10.2
 tqdm==4.56.0
 transformers==4.6.1
 sentencepiece==0.1.95
+sentence_transformers==2.0.0
 torch==1.8.1


### PR DESCRIPTION
This PR adds a new reranker based on a MiniLM cross-encoder pretrained on MS-MARCO provided by the SentenceTransformers package. MiniLM-based models are much faster than MonoT5/MonoBERT while maintaining a similar result when compared to MonoT5.

Although it adds a new dependency, SentenceTransformers handles smart batching and other optimizations that otherwise would need to be implemented in PyGaggle. I also added AMP integration for FP16 inference, which should make inferences even faster (I can add this to other models if that's desirable).

Besides MiniLM-based models, there is a [list of supported models](https://huggingface.co/cross-encoder).