### PR TITLE
Replication of DPR experiment 

### DIFF
--- a/docs/experiments-dpr-reader.md
+++ b/docs/experiments-dpr-reader.md
@@ -215,3 +215,4 @@ Please mention in your PR if you find any difference!
 ## Replication Log
 
 + Results replicated by [@MXueguang](https://github.com/MXueguang) on 2021-04-11 (commit[`1c1fb64`](1c1fb644ec7bca65a507ed2cc3a1ada21a2a5976)) (RTX 2080)
++ Results replicated by [@mayankanand007](https://github.com/mayankanand007) on 2021-08-16 (commit[`dda194f`](dda194f4546af0db62c317bbaf5ccd58edae0591))

--- a/docs/experiments-dpr-reader.md
+++ b/docs/experiments-dpr-reader.md
@@ -2,6 +2,8 @@
 
 This page contains instructions for running the Dense Passage Retrieval tools.
 
+Note: If you're using Compute Canada clusters for replicating this experiment, then first do `export PYTHONPATH=` to which will clear the python path. 
+
 First, clone the PyGaggle repository recursively.
 
 ```

--- a/docs/experiments-dpr-reader.md
+++ b/docs/experiments-dpr-reader.md
@@ -2,7 +2,12 @@
 
 This page contains instructions for running the Dense Passage Retrieval tools.
 
-Note: If you're using Compute Canada clusters for replicating this experiment, then first do `export PYTHONPATH=` to which will clear the python path. 
+Note: If you're using Compute Canada clusters for replicating this experiment, then do 
+
+```
+export PYTHONPATH=
+export PIP_CONFIG_FILE=
+``` 
 
 First, clone the PyGaggle repository recursively.
 
@@ -22,10 +27,7 @@ Then install PyGaggle by the following command.
 ```
 pip install -r requirements.txt
 ```
-Note: On Compute Canada, you may have to install tensorflow separately by the following command.
-```
-pip install tensorflow_gpu 
-```
+Note: To run the commands below on a Compute Canada cluster, make sure you're on a compute node as login node won't have enough memory to support these operations and you may get segmentation faults trying to run these. If GPU resources are not allocated, then commands can be run with the flag `--device cpu`
 
 ## Models
 


### PR DESCRIPTION
Environment: Compute Canada (Cedar), Memory = 64 GB, GPUs = 1

Updated installation instructions specific to CC, removed the additional command to install `tensorflow_gpu` as tensorflow is already in `requirements.txt`