### PR TITLE
Adding support for multilingual MonoT5 reranker

### DIFF
--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -32,17 +32,17 @@ __all__ = ['MonoT5',
            'SentenceTransformersReranker']
 
 prediction_tokens = {
-        'castorini/monot5-base-msmarco':          ['false', 'true'],
-        'castorini/monot5-base-msmarco-10k':      ['false', 'true'],
-        'castorini/monot5-large-msmarco':         ['false', 'true'],
-        'castorini/monot5-large-msmarco-10k':     ['false', 'true'],
-        'castorini/monot5-base-med-msmarco':      ['false', 'true'],
-        'castorini/monot5-3b-med-msmarco':        ['false', 'true'],
-        'unicamp-dl/ptt5-base-msmarco-pt-10k':     ['não'  , 'sim'],
-        'unicamp-dl/ptt5-base-msmarco-pt-100k':    ['não'  , 'sim'],
-        'unicamp-dl/ptt5-base-msmarco-en-pt-10k':  ['não'  , 'sim'],
-        'unicamp-dl/mt5-base-multi-msmarco':       ['no'   , 'yes'],
-        'unicamp-dl/mt5-base-en-pt-msmarco':       ['no'   , 'yes']
+        'castorini/monot5-base-msmarco':          ['▁false', '▁true'],
+        'castorini/monot5-base-msmarco-10k':      ['▁false', '▁true'],
+        'castorini/monot5-large-msmarco':         ['▁false', '▁true'],
+        'castorini/monot5-large-msmarco-10k':     ['▁false', '▁true'],
+        'castorini/monot5-base-med-msmarco':      ['▁false', '▁true'],
+        'castorini/monot5-3b-med-msmarco':        ['▁false', '▁true'],
+        'unicamp-dl/ptt5-base-msmarco-pt-10k':     ['▁não'  , '▁sim'],
+        'unicamp-dl/ptt5-base-msmarco-pt-100k':    ['▁não'  , '▁sim'],
+        'unicamp-dl/ptt5-base-msmarco-en-pt-10k':  ['▁não'  , '▁sim'],
+        'unicamp-dl/mt5-base-multi-msmarco':       ['▁no'   , '▁yes'],
+        'unicamp-dl/mt5-base-en-pt-msmarco':       ['▁no'   , '▁yes']
         }
 
 
@@ -83,26 +83,14 @@ class MonoT5(Reranker):
         if not token_false:
             if pretrained_model_name_or_path in prediction_tokens:
                 token_false, token_true = prediction_tokens[pretrained_model_name_or_path]
-                token_false = tokenizer.tokenizer.get_vocab()['▁' + token_false]
-                token_true  = tokenizer.tokenizer.get_vocab()['▁' + token_true]
+                token_false = tokenizer.tokenizer.get_vocab()[token_false]
+                token_true  = tokenizer.tokenizer.get_vocab()[token_true]
                 return (token_false, token_true)
             else:
                 raise Exception("We don't know the indexes for the non-relevant/relevant tokens for\
                         the checkpoint {pretrained_model_name_or_path} and you did not provide any.")
 
-
-
     def rescore(self, query: Query, texts: List[Text]) -> List[Text]:
-        '''
-        if not self.token_false:
-            if self.pretrained_model_name_or_path in prediction_tokens:
-                token_false, token_true = prediction_tokens[self.pretrained_model_name_or_path]
-                self.token_false = self.tokenizer.tokenizer.get_vocab()['▁' + token_false]
-                self.token_true  = self.tokenizer.tokenizer.get_vocab()['▁' + token_true]
-            else:
-                raise Exception("We don't know the indexes for the non-relevant/relevant tokens for\
-                        the checkpoint {pretrained_model_name_or_path} and you did not provide any.")
-        '''
         texts = deepcopy(texts)
         batch_input = QueryDocumentBatch(query=query, documents=texts)
         for batch in self.tokenizer.traverse_query_document(batch_input):

--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -78,19 +78,19 @@ class MonoT5(Reranker):
     @staticmethod
     def get_prediction_tokens(pretrained_model_name_or_path: str,
             tokenizer, token_false, token_true):
-        if not token_false:
+        if not (token_false and token_true):
             if pretrained_model_name_or_path in prediction_tokens:
                 token_false, token_true = prediction_tokens[pretrained_model_name_or_path]
                 token_false_id = tokenizer.tokenizer.get_vocab()[token_false]
                 token_true_id  = tokenizer.tokenizer.get_vocab()[token_true]
-                return (token_false_id, token_true_id)
+                return token_false_id, token_true_id
             else:
                 raise Exception("We don't know the indexes for the non-relevant/relevant tokens for\
                         the checkpoint {pretrained_model_name_or_path} and you did not provide any.")
         else:
             token_false_id = tokenizer.tokenizer.get_vocab()[token_false]
             token_true_id  = tokenizer.tokenizer.get_vocab()[token_true]
-            return (token_false_id, token_true_id)
+            return token_false_id, token_true_id
 
 
     def rescore(self, query: Query, texts: List[Text]) -> List[Text]:


### PR DESCRIPTION
Adding support for multilingual MonoT5 reranker.
Using AutoModelForSeq2SeqLM() for loading T5/mT5 models.
A list containing the models name with its predictions tokens was added to help users.