### PR TITLE
Update monoT5 constructor interface to fix issue #227

### DIFF
--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -49,11 +49,13 @@ prediction_tokens = {
 class MonoT5(Reranker):
     def __init__(self, 
                  pretrained_model_name_or_path: str  = 'castorini/monot5-base-msmarco',
+                 model: T5ForConditionalGeneration = None,
+                 tokenizer: QueryDocumentBatchTokenizer = None,
                  use_amp = False,
                  token_false = None,
                  token_true  = None):
-        self.model = self.get_model(pretrained_model_name_or_path)
-        self.tokenizer = self.get_tokenizer(pretrained_model_name_or_path)
+        self.model = model or self.get_model(pretrained_model_name_or_path)
+        self.tokenizer = tokenizer or self.get_tokenizer(pretrained_model_name_or_path)
         self.token_false_id, self.token_true_id = self.get_prediction_tokens(
                 pretrained_model_name_or_path, self.tokenizer, token_false, token_true)
         self.pretrained_model_name_or_path = pretrained_model_name_or_path

--- a/pygaggle/run/evaluate_document_ranker.py
+++ b/pygaggle/run/evaluate_document_ranker.py
@@ -81,7 +81,7 @@ def construct_t5(options: DocumentRankingEvaluationOptions) -> Reranker:
                              from_tf=options.from_tf,
                              device=options.device)
     tokenizer = MonoT5.get_tokenizer(options.model_type, batch_size=options.batch_size)
-    return MonoT5(model, tokenizer)
+    return MonoT5(model = model, tokenizer = tokenizer)
 
 
 def construct_transformer(options:

--- a/pygaggle/run/evaluate_kaggle_highlighter.py
+++ b/pygaggle/run/evaluate_kaggle_highlighter.py
@@ -72,7 +72,7 @@ def construct_t5(options: KaggleEvaluationOptions) -> Reranker:
     model = MonoT5.get_model(options.model,
                              device=options.device)
     tokenizer = MonoT5.get_tokenizer(options.model, batch_size=options.batch_size)
-    return MonoT5(model, tokenizer)
+    return MonoT5(model = model, tokenizer = tokenizer)
 
 
 def construct_transformer(options: KaggleEvaluationOptions) -> Reranker:

--- a/pygaggle/run/evaluate_passage_ranker.py
+++ b/pygaggle/run/evaluate_passage_ranker.py
@@ -84,7 +84,7 @@ def construct_t5(options: PassageRankingEvaluationOptions) -> Reranker:
                              from_tf=options.from_tf,
                              device=options.device)
     tokenizer = MonoT5.get_tokenizer(options.model_type, batch_size=options.batch_size)
-    return MonoT5(model, tokenizer)
+    return MonoT5(model = model, tokenizer = tokenizer)
 
 
 def construct_duo_t5(options: PassageRankingEvaluationOptions) -> Tuple[Reranker, Reranker]:


### PR DESCRIPTION
The interface to construct monoT5 is updated in this PR (castorini#212).

However there are several places where a instance of monoT5 is constructed in the old way. This resulted in the issue (#227).

Aside from that, note that currently we are using these when constructing a monoT5 instance:
```
self.get_model(pretrained_model_name_or_path)
self.get_tokenizer(pretrained_model_name_or_path)
```
However "pretrained_model_name_or_path" for model and tokenizer can be different. For example: for model it can be 'castorini/monot5-base-msmarco' and for tokenizer it can be 't5-base'. This may be a source of future bug.
