### PR TITLE
changed metric naming for clarification

### DIFF
--- a/pygaggle/data/kaggle.py
+++ b/pygaggle/data/kaggle.py
@@ -79,15 +79,15 @@ class LitReviewDataset(BaseModel):
             int_rels = np.array(list(map(int, rels)))
             p = int_rels.sum()
             mean_stats['Average spans'].append(p)
-            mean_stats['Random P@1'].append(np.mean(int_rels))
+            mean_stats['Expected P@1 for Random Ordering'].append(np.mean(int_rels))
             n = len(int_rels) - p
             N = len(int_rels)
-            mean_stats['Random R@3'].append(1 - (n * (n - 1) * (n - 2)) / (N * (N - 1) * (N - 2)))
+            mean_stats['Expected R@3 for Random Ordering'].append(1 - (n * (n - 1) * (n - 2)) / (N * (N - 1) * (N - 2)))
             numer = np.array([sp.comb(n, i) / (N - i) for i in range(0, n + 1)]) * p
             denom = np.array([sp.comb(N, i) for i in range(0, n + 1)])
             rr = 1 / np.arange(1, n + 2)
             rmrr = np.sum(numer * rr / denom)
-            mean_stats['Random MRR'].append(rmrr)
+            mean_stats['Expected MRR for Random Ordering'].append(rmrr)
             if not any(rels):
                 logging.warning(f'{doc_id} has no relevant answers')
         for k, v in mean_stats.items():

--- a/pygaggle/data/msmarco.py
+++ b/pygaggle/data/msmarco.py
@@ -118,20 +118,20 @@ class MsMarcoDataset(BaseModel):
         for ex in self.examples:
             int_rels = np.array(list(map(int, example_map[ex.qid][3])))
             p = int_rels.sum()/(len(ex.candidates) - 1) if is_duo else int_rels.sum()
-            mean_stats['Random P@1'].append(np.mean(int_rels))
+            mean_stats['Expected P@1 for Random Ordering'].append(np.mean(int_rels))
             n = len(ex.candidates) - p
             N = len(ex.candidates)
             if len(ex.candidates) <= 1000:
-                mean_stats['Random R@1000'].append(1 if 1 in int_rels else 0)
+                mean_stats['Expected R@1000 for Random Ordering'].append(1 if 1 in int_rels else 0)
             numer = np.array([sp.comb(n, i) / (N - i) for i in range(0, n + 1) if i != N]) * p
             if n == N:
                 numer = np.append(numer, 0)
             denom = np.array([sp.comb(N, i) for i in range(0, n + 1)])
             rr = 1 / np.arange(1, n + 2)
             rmrr = np.sum(numer * rr / denom)
-            mean_stats['Random MRR'].append(rmrr)
+            mean_stats['Expected MRR for Random Ordering'].append(rmrr)
             rmrr10 = np.sum(numer[:10] * rr[:10] / denom[:10])
-            mean_stats['Random MRR@10'].append(rmrr10)
+            mean_stats['Expected MRR@10 for Random Ordering'].append(rmrr10)
             ex_index = len(ex.candidates)
             for rel_cand in ex.relevant_candidates:
                 if rel_cand in ex.candidates:

--- a/pygaggle/data/trec_covid.py
+++ b/pygaggle/data/trec_covid.py
@@ -118,20 +118,20 @@ class TRECCovidDataset(BaseModel):
         for ex in self.examples:
             int_rels = np.array(list(map(int, example_map[ex.qid][3])))
             p = int(int_rels.sum())
-            mean_stats['Random P@1'].append(np.mean(int_rels))
+            mean_stats['Expected P@1 for Random Ordering'].append(np.mean(int_rels))
             n = len(ex.candidates) - p
             N = len(ex.candidates)
             if len(ex.candidates) <= 1000:
-                mean_stats['Random R@1000'].append(1 if 1 in int_rels else 0)
+                mean_stats['Expected R@1000 for Random Ordering'].append(1 if 1 in int_rels else 0)
             numer = np.array([sp.comb(n, i) / (N - i) for i in range(0, n + 1) if i != N]) * p
             if n == N:
                 numer = np.append(numer, 0)
             denom = np.array([sp.comb(N, i) for i in range(0, n + 1)])
             rr = 1 / np.arange(1, n + 2)
             rmrr = np.sum(numer * rr / denom)
-            mean_stats['Random MRR'].append(rmrr)
+            mean_stats['Expected MRR for Random Ordering'].append(rmrr)
             rmrr10 = np.sum(numer[:10] * rr[:10] / denom[:10])
-            mean_stats['Random MRR@10'].append(rmrr10)
+            mean_stats['Expected MRR@10 for Random Ordering'].append(rmrr10)
             ex_index = len(ex.candidates)
             for rel_cand in ex.relevant_candidates:
                 if rel_cand in ex.candidates:


### PR DESCRIPTION
The naming `Random P@1` is confusing for users of pygaggle who are not completely familiar with the codebase. If someone is trying compare P@1 of their first-stage ranker (e.g. BM25) and P@1 after reranking, when they see `Random P@1`, they may interpret it as `FirstStage P@1` (aka. `Existing P@1`). However,  [this line](https://github.com/castorini/pygaggle/blob/master/pygaggle/data/msmarco.py#L121) implies that it is actually `P@K` where `K` is the size of the ranked list (e.g. 1,000). Interpreted differently, it is the expected P@1 of a random ordering of the candidate texts, which after discussing with @ronakice seems to be the intention.

I am not a big fan of the new name I chose `Expected METRIC for Random Ordering` (it seems too long). Other suggestions are welcomed. But clarity is more important than conciseness in my opinion.
