### PR TITLE
Update experiments-msmarco-passage-subset.md

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -179,3 +179,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@mzzchy](https://github.com/mzzchy) on 2021-08-29 (commit[`6b9c895`](https://github.com/castorini/pygaggle/commit/b5315e9f1f7466e689983e3c4e70134e36d4be49)) (GeForce GTX 1660 Ti)
 + Results replicated by [@AlexWang000](https://github.com/AlexWang000) on 2021-10-22 (commit[`63f92cf`](https://github.com/castorini/pygaggle/commit/63f92cf6f83a8909f4bf6528b402632d7498b8d6)) (Tesla T4 on Colab)
 + Results replicated by [@manveertamber](https://github.com/manveertamber) on 2021-12-08 (commit[`b3e11c4`](https://github.com/castorini/pygaggle/commit/b3e11c46a6cf17e0e99a8eed7de316eb0117ee19)) (GeForce GTX 1660)
++ Results reproduced by [@lingwei-gu](https://github.com/lingwei-gu) on 2022-01-05 (commit [`d671f62`](https://github.com/castorini/pygaggle/commit/d671f62e4a269b5d79068f25267edd6078e568b5)) (Tesla T4 on Colab)


### PR DESCRIPTION
It seems that pygaggle requires/installs transformers==4.0.0, but I had to install transformers==4.6.0 to make it work. Otherwise there were version errors
Colab was used for the reproduction.