### PR TITLE
Fix transformer.py fstring

### DIFF
--- a/pygaggle/rerank/transformer.py
+++ b/pygaggle/rerank/transformer.py
@@ -94,7 +94,7 @@ class MonoT5(Reranker):
                 token_true_id  = tokenizer.tokenizer.get_vocab()[token_true]
                 return token_false_id, token_true_id
             else:
-                raise Exception("We don't know the indexes for the non-relevant/relevant tokens for\
+                raise Exception(f"We don't know the indexes for the non-relevant/relevant tokens for\
                         the checkpoint {pretrained_model_name_or_path} and you did not provide any.")
         else:
             token_false_id = tokenizer.tokenizer.get_vocab()[token_false]


### PR DESCRIPTION
Recently i came acrosss this error and the message was wrong ( the variable name was printed, and not it's value), this PR just fixes the typo (missing f in the fstring) in the exception message.