### PR TITLE
Append to MS MARCO Passage Retrieval Subset reproduction log

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -180,4 +180,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@AlexWang000](https://github.com/AlexWang000) on 2021-10-22 (commit[`63f92cf`](https://github.com/castorini/pygaggle/commit/63f92cf6f83a8909f4bf6528b402632d7498b8d6)) (Tesla T4 on Colab)
 + Results replicated by [@manveertamber](https://github.com/manveertamber) on 2021-12-08 (commit[`b3e11c4`](https://github.com/castorini/pygaggle/commit/b3e11c46a6cf17e0e99a8eed7de316eb0117ee19)) (GeForce GTX 1660)
 + Results replicated by [@lingwei-gu](https://github.com/lingwei-gu) on 2022-01-05 (commit [`d671f62`](https://github.com/castorini/pygaggle/commit/d671f62e4a269b5d79068f25267edd6078e568b5)) (Tesla T4 on Colab)
-
++ Results replicated by [@jx3yang](https://github.com/jx3yang) on 2022-05-10 (commit[`a326d49`](https://github.com/castorini/pygaggle/commit/a326d4983db6f84e4c519efa9e2dec91f776268e)) (Tesla T4 on Colab)


### PR DESCRIPTION
## Description
Reproduced the neural reranking baselines on the MS MARCO passage subset.

## Environment
- Ubuntu 18.04.5 LTS
- Python 3.7.13
- GPU: Tesla T4 (Google Colab)
- CUDA Version: 11.6

## Issue Encountered
Ran into the following error when evaluating monoBERT:

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/root/pygaggle/pygaggle/run/evaluate_passage_ranker.py", line 13, in <module>
    from pygaggle.rerank.base import Reranker
  File "/root/pygaggle/pygaggle/rerank/base.py", line 5, in <module>
    from pyserini.search import JSimpleSearcherResult
  File "/usr/local/lib/python3.7/dist-packages/pyserini/search/__init__.py", line 20, in <module>
    from ._impact_searcher import JImpactSearcherResult, ImpactSearcher
  File "/usr/local/lib/python3.7/dist-packages/pyserini/search/_impact_searcher.py", line 28, in <module>
    from pyserini.encode import QueryEncoder, TokFreqQueryEncoder, UniCoilQueryEncoder, CachedDataQueryEncoder
  File "/usr/local/lib/python3.7/dist-packages/pyserini/encode/__init__.py", line 17, in <module>
    from ._base import DocumentEncoder, QueryEncoder, JsonlCollectionIterator,\
  File "/usr/local/lib/python3.7/dist-packages/pyserini/encode/_base.py", line 19, in <module>
    import faiss
ModuleNotFoundError: No module named 'faiss'
```

Resolved with `pip install faiss-cpu`. The problem most likely comes from the fact that `pyserini` depends on `faiss`, but the latter is not listed in the former's `requirements.txt` file.