### PR TITLE
Reproduced msmarco passage retrieval dev subset results

### DIFF
--- a/docs/experiments-msmarco-passage-subset.md
+++ b/docs/experiments-msmarco-passage-subset.md
@@ -181,3 +181,4 @@ If you were able to replicate these results, please submit a PR adding to the re
 + Results replicated by [@manveertamber](https://github.com/manveertamber) on 2021-12-08 (commit[`b3e11c4`](https://github.com/castorini/pygaggle/commit/b3e11c46a6cf17e0e99a8eed7de316eb0117ee19)) (GeForce GTX 1660)
 + Results replicated by [@lingwei-gu](https://github.com/lingwei-gu) on 2022-01-05 (commit [`d671f62`](https://github.com/castorini/pygaggle/commit/d671f62e4a269b5d79068f25267edd6078e568b5)) (Tesla T4 on Colab)
 + Results replicated by [@jx3yang](https://github.com/jx3yang) on 2022-05-10 (commit[`a326d49`](https://github.com/castorini/pygaggle/commit/a326d4983db6f84e4c519efa9e2dec91f776268e)) (Tesla T4 on Colab)
++ Results replicated by [@alvind1](https://github.com/alvind1) on 2022-05-12 (commit[`9d859a1`](https://github.com/castorini/pygaggle/commit/9d859a16d38e1c4281ac3c0588a4fa00e9e39e9a)) (Tesla T4 on Colab)


### PR DESCRIPTION
Environment
- GPU: Tesla T4 (Colab)
- Python 3.7.13
- Ubuntu 18.04.5 LTS

Also ran into the issue of "No module named faiss"
Resolved with `pip install faiss-gpu`

MonoBert Results
<img width="713" alt="image" src="https://user-images.githubusercontent.com/40304595/168177117-ac4d5928-3b69-4831-81e5-b2870f0ecdf4.png">

MonoT5 Results
<img width="649" alt="image" src="https://user-images.githubusercontent.com/40304595/168177173-47fa2df2-24b9-4bb7-b398-a7189cf0436c.png">

