### PR TITLE
Fix FiD text_maxlength

### DIFF
--- a/pygaggle/qa/fid_reader.py
+++ b/pygaggle/qa/fid_reader.py
@@ -76,7 +76,7 @@ class FidReader(Reader):
             outputs = self.model.generate(
                 input_ids=context_ids.to(self.device),
                 attention_mask=context_mask.to(self.device),
-                max_length=self.text_maxlength #from dpr_reader
+                max_length=350 #from dpr_reader
             )
             for k, o in enumerate(outputs):
                 ans = self.tokenizer.decode(o, skip_special_tokens=True)

--- a/pygaggle/run/evaluate_fid_reader.py
+++ b/pygaggle/run/evaluate_fid_reader.py
@@ -80,6 +80,7 @@ class PassageReadingEvaluationOptions(BaseModel):
     num_spans: int
     max_answer_length: int
     num_spans_per_passage: int
+    text_maxlength: int
     device: str
     batch_size: int
     topk_em: List[int]
@@ -160,9 +161,9 @@ def main():
             required=True,
             help='File to output predictions for each example; if not specified, this output will be discarded'),
         opt('--text_maxlength',
-            type=Path,
-            default=None,
-            required=True,
+            type=int,
+            default=250,
+            required=False,
             help='File to output predictions for each example; if not specified, this output will be discarded'),
         opt('--device',
             type=str,

--- a/pygaggle/run/evaluate_fid_reader.py
+++ b/pygaggle/run/evaluate_fid_reader.py
@@ -95,8 +95,7 @@ def construct_fid(options: PassageReadingEvaluationOptions) -> Reader:
                      options.num_spans,
                      options.max_answer_length,
                      options.num_spans_per_passage,
-                    #  options.text_maxlength,
-                     200,
+                     options.text_maxlength,
                      options.batch_size,
                      options.device)
 
@@ -141,7 +140,7 @@ def main():
             help='Pretrained model for reader'),
         opt('--tokenizer-name',
             type=str,
-            default='facebook/dpr-reader-single-nq-base',
+            default='t5-base',
             help='Pretrained model for tokenizer'),
         opt('--num-spans',
             type=int,
@@ -156,6 +155,11 @@ def main():
             default=10,
             help='Maximum number of answer spans to return per passage'),
         opt('--output-file',
+            type=Path,
+            default=None,
+            required=True,
+            help='File to output predictions for each example; if not specified, this output will be discarded'),
+        opt('--text_maxlength',
             type=Path,
             default=None,
             required=True,
@@ -236,7 +240,7 @@ def main():
     em = np.mean(np.array(scores)) * 100.
     logging.info(f'Exact Match Accuracy: {em}')
 
-    with open("reader_output.nq_test.fid_base.json", 'w', encoding='utf-8', newline='\n') as f:
+    with open(args.output_file, 'w', encoding='utf-8', newline='\n') as f:
         json.dump(results, f, indent=4)
 
 

--- a/pygaggle/run/evaluate_fid_reader.py
+++ b/pygaggle/run/evaluate_fid_reader.py
@@ -164,7 +164,7 @@ def main():
             type=int,
             default=250,
             required=False,
-            help='File to output predictions for each example; if not specified, this output will be discarded'),
+            help='maximum number of tokens in text segments (question+passage)'),
         opt('--device',
             type=str,
             default='cuda:0',


### PR DESCRIPTION
As per the original FiD paper, text_maxlength i.e. the maximum number of tokens in text segments (question+passage), should be limited to 250. In our codebase, it was being limited to 350. From some testing I did, this did not make a huge difference in results, perhaps because most (question + 100-word passage) text segments were within this limit anyway. 