### PR TITLE
Update environment.yml to work on m1 macbooks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,9 @@ name: pygaggle
 channels:
   - defaults
 dependencies:
+  - python=3.8
+  - conda-forge::openjdk
+  - conda-forge::tensorflow
   - pip:
     - coloredlogs==14.0
     - dataclasses;python_version<"3.7"
@@ -11,11 +14,10 @@ dependencies:
     - scikit-learn==0.24.2
     - scipy==1.5.4
     - spacy>=3.2.1
-    - tensorboard==2.5.0
-    - tensorflow==2.5.0
     - tokenizers==0.10.2
     - tqdm==4.56.0
     - transformers==4.6.1
     - sentencepiece==0.1.95
     - sentence_transformers==2.0.0
     - torch>=1.8.1
+    - faiss-cpu>=1.7.3


### PR DESCRIPTION
Update `environment.yml` to work on m1 mac.

### Environment
Device: MacBook Air (M2 chip)
OS: MacOS Ventura 13.3
Using x86 Anaconda

### Testing
Tried the Simple Reranking Example (https://github.com/castorini/pygaggle#a-simple-reranking-example) after creating a conda environment with `conda env create -f environment.yml`. Ran successfully without errors.

Would appreciate if someone on a different platform could test it out as well before merging.